### PR TITLE
actions/dispatch: support dispatch to multiple target repos

### DIFF
--- a/actions/dispatch/entrypoint/main.go
+++ b/actions/dispatch/entrypoint/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	if config.Repos == "" {
-		fail(errors.New("missing required input \"repo\""))
+		fail(errors.New("missing required input \"repos\""))
 	}
 
 	if config.Token == "" {


### PR DESCRIPTION
Co-authored-by: Arjun Sreedharan <asreedharan@vmware.com>

This resolves a blocker mentioned in #6, and useful for implementation cnbs that are referenced in multiple language families.

cc @thitch97 