### PR TITLE
Changes versioning logic

### DIFF
--- a/actions/tag/entrypoint
+++ b/actions/tag/entrypoint
@@ -6,9 +6,8 @@
 main() {
   previous="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
   tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
-  tag="$(printf "v%s" "${tag#v}")"
 
-  echo "::set-output name=tag::${tag}"
+  echo "::set-output name=tag::${tag#v}"
 }
 
 main "${@:-}"

--- a/implementation/.github/workflows/create-release.yml
+++ b/implementation/.github/workflows/create-release.yml
@@ -72,8 +72,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.tag.outputs.tag }}
-        release_name: ${{ steps.tag.outputs.tag }}
+        tag_name: v${{ steps.tag.outputs.tag }}
+        release_name: v${{ steps.tag.outputs.tag }}
         body: ${{ steps.create-release-notes.outputs.release_body }}
         draft: false
         prerelease: false


### PR DESCRIPTION
This change make it so that the version sting is v prepended for the github tag and release name but no where else. This was causing issues creating buildpackages because the versions that we provided in buildpack.tomls of the implementation buildpacks and meta buildpacks did not line up.

I decided to keep the v prepended to the tag and title on github on after reading [this](https://semver.org/#is-v123-a-semantic-version) from the semver spec.