### PR TITLE
Propagate changes to implementation-cnbs

### DIFF
--- a/.github/data/implementation-cnbs
+++ b/.github/data/implementation-cnbs
@@ -1,0 +1,17 @@
+paketo-buildpacks/node-engine
+paketo-buildpacks/npm
+paketo-buildpacks/yarn-install
+paketo-buildpacks/go-compiler
+paketo-buildpacks/go-mod
+paketo-buildpacks/dep
+paketo-buildpacks/httpd
+paketo-buildpacks/nginx
+paketo-buildpacks/php-dist
+paketo-buildpacks/php-composer
+paketo-buildpacks/php-web
+paketo-buildpacks/icu
+paketo-buildpacks/dotnet-core-runtime
+paketo-buildpacks/dotnet-core-aspnet
+paketo-buildpacks/dotnet-core-sdk
+paketo-buildpacks/dotnet-core-build
+paketo-buildpacks/dotnet-core-conf

--- a/.github/data/language-family-cnbs
+++ b/.github/data/language-family-cnbs
@@ -1,0 +1,4 @@
+paketo-buildpacks/nodejs
+paketo-buildpacks/go
+paketo-buildpacks/php
+paketo-buildpacks/dotnet-core

--- a/.github/workflows/notify-implementation.yml
+++ b/.github/workflows/notify-implementation.yml
@@ -1,0 +1,40 @@
+# Notifies implementation cnb repos that they have to pickup a change
+# Requirements:
+# ${{ secrets.BOT_USER_TOKEN }} : token with dispatch privileges
+
+name: Notify Implementation CNB repos
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - 'implementation/**'
+
+jobs:
+
+  dispatch:
+    runs-on: ubuntu-latest
+    name: Send Dispatch
+    steps:
+
+    - name: Check out
+      uses: actions/checkout@v2
+
+    - name: Targets
+      id: targets
+      run : |
+        targetlist=$(awk -vORS=, '{print}' .github/data/implementation-cnbs | sed 's#,$#\n#')
+        echo "::set-output name=targetlist::$targetlist"
+
+    - name: Send Repository Dispatch
+      uses: paketo-buildpacks/github-config/actions/dispatch@master
+      with:
+        repos: "${{ steps.targets.outputs.targetlist }}"
+        token: ${{ secrets.BOT_USER_TOKEN }}
+        event: working-dir-update
+        payload: |
+          {
+            "commit": "${{ github.sha }}",
+            "srcpath": "/implementation"
+          }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# github-config
-Common repository configuration
+# Github config
+
+This repository contains config files common to implementation and language-family
+CNBs.
+
+## Rules
+
+Run [scripts/sanity.sh](scripts/sanity.sh) to see if the changes you made to this repo are valid.
+
+## How do I consume this common config
+
+If you just wrote a new CNB, run [bootstrap.sh](scripts/bootstrap.sh) as follows:
+```sh
+# type is either "implementation" or "language-family"
+./scripts/bootstrap.sh <path/to/your/cnb> <type>
+```
+
+This will copy the relevant config files to your CNB. Git commit and Push your CNB.
+
+Now, to wire up your CNB repo to receive relevant updates as a pull requests:
+* Append your repo name to the relevant file [here](.github/data)
+* Configure deploy-keys, secrets as required in workflow
+* To auto-merge these PRs, turn on [mergify](https://github.com/marketplace/mergify) for your cnb repo
+
+Submit your change to this repo as a PR. You should be all set when the PR is merged.
+

--- a/implementation/.github/workflows/receive-github-config-updates.yml
+++ b/implementation/.github/workflows/receive-github-config-updates.yml
@@ -1,0 +1,82 @@
+# Receives notification from github-config repo and creates PR
+# Requirements:
+# ${{ secrets.DEPLOY_KEY_PRIVATE}}: Private key of a deploy key pair
+# with write access that you have added to your repo
+# Future TODO: Mv reusable logic to an action when writing lang-fam receiver
+
+name: Create PR from github-config notification
+
+on:
+  repository_dispatch:
+    types: working-dir-update
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: Update github config
+    steps:
+
+    - name: parse inputs
+      id: read-inputs
+      run: |
+        echo "::set-output name=commit::$(jq -r .client_payload.commit ${{ github.event_path }})"
+        echo "::set-output name=srcpath::$(jq -r .client_payload.srcpath ${{ github.event_path }})"
+
+    # checkout github-config @$commit
+    - name: Checkout github-config repo
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        ref: "${{ steps.read-inputs.outputs.commit }}"
+        path: src-repo
+
+    # checkout this repo
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: dst-repo
+
+    - name: Checkout PR Branch
+      id: pr-branch
+      run: |
+        pushd src-repo
+          BRANCH_NAME="github-config-$(git rev-parse HEAD | head -c7)"
+        popd
+        pushd dst-repo
+          git checkout -b "$BRANCH_NAME"
+          echo "::set-output name=branch::$BRANCH_NAME"
+        popd
+
+    - name: Copy all dirs
+      run: |
+        pushd "src-repo${{ steps.read-inputs.outputs.srcpath }}"
+          for dir in $(ls -Apq . | grep "/"); do
+            cp -ar "$dir" "${{ github.workspace }}/dst-repo"
+          done
+        popd
+
+    - name: Commit and Push
+      env:
+        SSH_KEY: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+      run: |
+        pushd dst-repo
+          git config user.email "paketobuildpacks@paketo.io"
+          git config user.name "paketo-bot"
+          git commit --all --message "Update shared github-config"
+          git remote add origin-ssh git@github.com:${{ github.repository }}
+          eval "$(ssh-agent)"
+          echo "$SSH_KEY" | ssh-add -
+          git push origin-ssh "${{ steps.pr-branch.outputs.branch }}"
+        popd
+
+    - name: Open Pull Request
+      run: |
+        curl "https://api.github.com/repos/${{ github.repository }}/pulls" \
+          -H "Authorization: token ${{ github.token }}" \
+          -X POST \
+          --data '{
+            "head": "${{ steps.pr-branch.outputs.branch }}",
+            "base": "master",
+            "title": "Update shared github-config",
+            "body": ""
+          }'

--- a/implementation/.mergify/config.yml
+++ b/implementation/.mergify/config.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Auto merge pull requests from github-actions bot
+    conditions:
+      - author=github-actions[bot]
+      # TODO: Fill in these conditions when they are finalized
+      # - status-success=Unit Tests
+      # - status-success=Integration Tests
+    actions:
+      merge:
+        strict: true
+        method: rebase
+      delete_head_branch: {}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Use to bootstrap cnbs with shared files
+set -euo pipefail
+
+if [  $# -ne 2 ]; then
+    echo "usage: $0 <dst-cnb-dir> <implementation|language-family>"; exit 1;
+fi
+
+target="$1"
+type="$2"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DIR"/sanity.sh
+
+check_sanity
+
+[ -d "$target" ] || { echo "$target" dir not found; exit  1; }
+
+if [ "$type" != "implementation" ] && [ "$type" != "language-family" ]; then
+    echo Invalid cnb type; exit 1
+fi
+
+cp -pR "${DIR}/../${type}/." "$target"

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Checks if the contents of implementation/ and language-family/ follow rules
+# Future TODO: Run this on every PR
+set -euo pipefail
+
+ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+check_sanity () {
+    # Rule 1 - all children of implemenation/ & language-family/ must be directories
+    for cnbdir in 'implementation' 'language-family' ; do
+        [ -d "$ROOTDIR"/"$cnbdir" ] || { echo "$cnbdir" dir not found; exit  1; }
+        if [ $(ls -Apq "$ROOTDIR"/"$cnbdir" | grep -v /) ]; then
+            echo All files in "$cnbdir/" must be directories. Exiting.
+            exit 1
+        fi
+    done
+}
+
+check_sanity "$@"


### PR DESCRIPTION
- list of target repos in .github/data
- worklow in .github notifies target repos on relevant change
- implementation/.github has workflow to receive notification
and create PR
- mergify config will auto merge the PR at the target

See [README.md](https://github.com/paketo-buildpacks/github-config/blob/propagate-implementation/README.md) for expected use