### PR TITLE
impl/mergify: add rules for paketo-bot, dependabot

### DIFF
--- a/implementation/.mergify/config.yml
+++ b/implementation/.mergify/config.yml
@@ -1,10 +1,35 @@
+# Requirement:
+# Mergify app must be installed at the target repository
+# See github.com/<org>/<repo>/settings/installations
+
 pull_request_rules:
   - name: Auto merge pull requests from github-actions bot
     conditions:
       - author=github-actions[bot]
-      # TODO: Fill in these conditions when they are finalized
-      # - status-success=Unit Tests
-      # - status-success=Integration Tests
+      - status-success=Unit Tests
+      - status-success=Integration Tests
+    actions:
+      merge:
+        strict: true
+        method: rebase
+      delete_head_branch: {}
+
+  - name: Auto merge pull requests from paketo-bot user
+    conditions:
+      - author=paketo-bot
+      - status-success=Unit Tests
+      - status-success=Integration Tests
+    actions:
+      merge:
+        strict: true
+        method: rebase
+      delete_head_branch: {}
+
+  - name: Auto merge pull requests from Dependabot bot
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success=Unit Tests
+      - status-success=Integration Tests
     actions:
       merge:
         strict: true


### PR DESCRIPTION
As of now, mergify has been turned on for node-engine (https://github.com/paketo-buildpacks/node-engine/settings/installations). We'd like to see how things go and start turning mergify on for other repos in the future.