### PR TITLE
add check for already commited tags

### DIFF
--- a/actions/tag/entrypoint
+++ b/actions/tag/entrypoint
@@ -4,10 +4,13 @@
 # before executing this script
 
 main() {
+  if git describe --exact-match --tags HEAD > /dev/null 2>&1; then
+    echo "error: HEAD has already been tagged"
+    exit 1
+  fi
   previous="$(git describe --tags "$(git rev-list --tags --max-count=1)" || echo "v0.0.0")"
   tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
 
   echo "::set-output name=tag::${tag#v}"
 }
-
 main "${@:-}"


### PR DESCRIPTION
Just a small quality of life improvement.
Before these changes:
  re-running workflows to create a file would tag a commit a second time and create an awkward unusable duplicate draft release.

After these changes:
  re-running workflows that have cut a release will error out when trying to bump to a new tag.

Here is an example of this working: 
https://github.com/dwillist/puma/runs/721553534