### PR TITLE
Uses skopeo to push buildpackages to GCR

### DIFF
--- a/language-family/.github/workflows/push-buildpackage.yml
+++ b/language-family/.github/workflows/push-buildpackage.yml
@@ -16,8 +16,6 @@ jobs:
       env:
         GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
       run: |
-        echo "${GCR_PUSH_BOT_JSON_KEY}" | docker login --username _json_key --password-stdin https://gcr.io
-        docker image import "${GITHUB_WORKSPACE}/${{ steps.download.outputs.buildpackage }}" "gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}"
-        docker tag "gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}" "gcr.io/${{ github.repository }}:latest"
-        docker push "gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}"
-        docker push "gcr.io/${{ github.repository }}:latest"
+        echo "${GCR_PUSH_BOT_JSON_KEY}" | docker login --username _json_key --password-stdin gcr.io
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/${{ steps.download.outputs.buildpackage }}" "docker://gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/${{ steps.download.outputs.buildpackage }}" "docker://gcr.io/${{ github.repository }}:latest"


### PR DESCRIPTION
We've replace using docker to push these images because the `docker
image import` command loses metadata for the image that is then missing
on the remote. Skopeo keeps this metadata and doesn't use the docker
daemon.