### PR TITLE
scripts/tools.sh: Do not assume package exists

### DIFF
--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -130,6 +130,6 @@ function util::tools::packager::install () {
 
     if [[ ! -f "${dir}/packager" ]]; then
         util::print::title "Installing packager"
-        GOBIN="${dir}" go install github.com/cloudfoundry/libcfbuildpack/packager
+        GOBIN="${dir}" go get github.com/cloudfoundry/libcfbuildpack/packager
     fi
 }

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -129,6 +129,6 @@ function util::tools::packager::install () {
 
     if [[ ! -f "${dir}/packager" ]]; then
         util::print::title "Installing packager"
-        GOBIN="${dir}" go install github.com/cloudfoundry/libcfbuildpack/packager
+        GOBIN="${dir}" go get github.com/cloudfoundry/libcfbuildpack/packager
     fi
 }


### PR DESCRIPTION
- Imagine a case where the go.mod of the cnb does not list
libcfbuildpack. Then, you'll have to "get" it.

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>