### PR TITLE
Draft releases can be forced to specify a version

### DIFF
--- a/actions/release/reset-draft/action.yml
+++ b/actions/release/reset-draft/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Github Access Token used to make the request'
     required: true
 
+outputs:
+  current_version:
+    description: The version of the current draft release
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/actions/release/reset-draft/entrypoint/main.go
+++ b/actions/release/reset-draft/entrypoint/main.go
@@ -50,8 +50,9 @@ func main() {
 	}
 
 	var releases []struct {
-		ID    int  `json:"id"`
-		Draft bool `json:"draft"`
+		ID      int    `json:"id"`
+		Draft   bool   `json:"draft"`
+		TagName string `json:"tag_name"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&releases)
 	if err != nil {
@@ -92,6 +93,7 @@ func main() {
 		fail(fmt.Errorf("unexpected response from delete draft release request: %s", dump))
 	}
 
+	fmt.Printf("::set-output name=current_version::%s\n", releases[0].TagName)
 	fmt.Println("Success!")
 }
 

--- a/actions/release/reset-draft/entrypoint/main_test.go
+++ b/actions/release/reset-draft/entrypoint/main_test.go
@@ -61,7 +61,8 @@ func TestEntrypoint(t *testing.T) {
 					fmt.Fprintln(w, `[
 						{
 							"draft": true,
-							"id": 2
+							"id": 2,
+							"tag_name": "some-version"
 						}
 					]`)
 
@@ -141,7 +142,7 @@ func TestEntrypoint(t *testing.T) {
 		})
 
 		context("when a draft release does exists", func() {
-			it("deletes the draft release", func() {
+			it("deletes the draft release and outputs its version", func() {
 				command := exec.Command(
 					entrypoint,
 					"--endpoint", api.URL,
@@ -165,6 +166,7 @@ func TestEntrypoint(t *testing.T) {
 				Expect(buffer).To(gbytes.Say(`Fetching latest releases`))
 				Expect(buffer).To(gbytes.Say(`  Repository: some-org/draft-repo`))
 				Expect(buffer).To(gbytes.Say(`Latest release is draft, deleting.`))
+				Expect(buffer).To(gbytes.Say(`::set-output name=current_version::some-version`))
 				Expect(buffer).To(gbytes.Say(`Success`))
 			})
 		})

--- a/actions/tag/action.yml
+++ b/actions/tag/action.yml
@@ -3,6 +3,10 @@ name: 'Tag'
 description: |
   Tags the repository with the next highest patch number given an existing tag.
 
+inputs:
+  current_version:
+    description: 'If set will override script and use this version as the tag'
+
 outputs:
   tag:
     description: 'Tag produced from the action'
@@ -10,3 +14,6 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+  - --current-version
+  - ${{ inputs.current_version }}

--- a/actions/tag/entrypoint
+++ b/actions/tag/entrypoint
@@ -4,12 +4,37 @@
 # before executing this script
 
 main() {
+  local current_version
+
+  while [ "${#}" != 0 ]; do
+    case "${1}" in
+      --current-version)
+        current_version="${2}"
+        shift 2
+        ;;
+
+      "")
+        current_version=""
+        shift
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\""
+        exit 1
+    esac
+  done
+
   if git describe --exact-match --tags HEAD > /dev/null 2>&1; then
     echo "error: HEAD has already been tagged"
     exit 1
   fi
-  previous="$(git describe --tags "$(git rev-list --tags --max-count=1)" || echo "v0.0.0")"
-  tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
+
+  if [ -n "${current_version}" ]; then
+    tag="${current_version}"
+  else
+    previous="$(git describe --tags "$(git rev-list --tags --max-count=1)" || echo "v0.0.0")"
+    tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
+  fi
 
   echo "::set-output name=tag::${tag#v}"
 }


### PR DESCRIPTION
These changes to the `release/reset-draft` and `tag` actions will allow administrators to control more directly what version number will be used when cutting a new draft release. To change the release major or minor version, administrators will be able to draft a new empty release with that version bump and then re-trigger the "Create Draft Release" workflow on their repository.