### PR TITLE
Updates upstream Mergify config

### DIFF
--- a/implementation/.mergify/config.yml
+++ b/implementation/.mergify/config.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Auto merge pull requests from dependabot
+    conditions:
+      - author=dependabot[bot]
+      - status-success=Unit Tests
+      - status-success=Integration Tests
+    actions:
+      merge:
+        strict: smart
+        method: rebase
+        bot_account: paketo-bot
+      delete_head_branch: {}

--- a/language-family/.mergify/config.yml
+++ b/language-family/.mergify/config.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Auto merge pull requests from dependabot
+    conditions:
+      - author=dependabot[bot]
+      - status-success=Unit Tests
+      - status-success=Integration Tests
+    actions:
+      merge:
+        strict: smart
+        method: rebase
+        bot_account: paketo-bot
+      delete_head_branch: {}


### PR DESCRIPTION
This adds an upstream configuration file now that we have decided on a preliminary workflow for auto-merging dependabot updates with Mergify.

**Things to note:**
- The Mergify bot will need to be added to the list of users allowed to push to the base branch on each repo. To do this, navigate to the 'Branches' tab in the repo settings and select **"Restrict who can push to matching branches"**. Add `mergify` and the relevant list of maintainers for that repo to the allowed list.

- The `strict rebase` solution we have opted for has potential [drawbacks](https://doc.mergify.io/actions.html#strict-rebase) that may arise during our testing.
- The `bot_account` field specifies the account that will be used by Mergify when rebasing branches as it will need authorization.