### PR TITLE
Fix git branch exist check command

### DIFF
--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -80,7 +80,7 @@ function checkout_pr_branch() {
 
   git -C "${current_repo}" fetch origin
 
-  if git -C "${current_repo}" branch -vv -a | grep "${branch}"; then
+  if git -C "${current_repo}" branch -a | grep "${branch}"; then
     git -C "${current_repo}" checkout -b "${branch}" "origin/${branch}"
 
     git -C "${current_repo}" pull -r

--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         branch="automation/dependency-update/${{ steps.dependency.outputs.id }}"
         git fetch origin
-        if git branch -vv -a | grep "${branch}"; then
+        if git branch -a | grep "${branch}"; then
           git checkout -b "${branch}" "origin/${branch}"
           git pull -r
         else


### PR DESCRIPTION
git-branch verbose also prints out the commit subject line for each
HEAD. So a grep matches if the subject has something like "Merge pr from
@branch".

See:
- https://github.com/paketo-buildpacks/php-dist/actions/runs/190512860
-
https://github.com/paketo-buildpacks/php-composer/actions/runs/190512856

it looks like the check matches on:

> git branch -vv -a | grep "automation/github-config/update"
master  2985d66 [origin/master] Merge pull request #76 from paketo-buildpacks/automation/gi
thub-config/update
...

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>