### PR TITLE
Make unit/int tests exit non-zero when tests are focused

### DIFF
--- a/implementation/scripts/.util/print.sh
+++ b/implementation/scripts/.util/print.sh
@@ -36,7 +36,8 @@ function util::print::success() {
   reset="\033[0;39m"
 
   echo -e "${green}${message}${reset}" >&2
-  exit 0
+  exitcode="${2:-0}"
+  exit "${exitcode}"
 }
 
 function util::print::warn() {

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -132,3 +132,13 @@ function util::tools::packager::install () {
       GOBIN="${dir}" go get -u github.com/cloudfoundry/libcfbuildpack/packager
     fi
 }
+
+function util::tools::tests::checkfocus() {
+  testout="${1}"
+  if grep -q 'Focused: [1-9]' "${testout}"; then
+    echo "Detected Focused Test(s) - setting exit code to 197"
+    rm "${testout}"
+    util::print::success "** GO Test Succeeded **" 197
+  fi
+  rm "${testout}"
+}

--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -113,8 +113,11 @@ function token::fetch() {
 
 function tests::run() {
   util::print::title "Run Buildpack Runtime Integration Tests"
+
+  testout=$(mktemp)
   pushd "${BUILDPACKDIR}" > /dev/null
-    if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration; then
+    if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${testout}"; then
+      util::tools::tests::checkfocus "${testout}"
       util::print::success "** GO Test Succeeded **"
     else
       util::print::error "** GO Test Failed **"

--- a/implementation/scripts/unit.sh
+++ b/implementation/scripts/unit.sh
@@ -6,6 +6,9 @@ set -o pipefail
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${PROGDIR}/.util/tools.sh"
+
 # shellcheck source=SCRIPTDIR/.util/print.sh
 source "${PROGDIR}/.util/print.sh"
 
@@ -45,8 +48,10 @@ USAGE
 function unit::run() {
   util::print::title "Run Buildpack Unit Tests"
 
+  testout=$(mktemp)
   pushd "${BUILDPACKDIR}" > /dev/null
-    if go test ./... -v -run Unit; then
+    if go test ./... -v -run Unit | tee "${testout}"; then
+      util::tools::tests::checkfocus "${testout}"
       util::print::success "** GO Test Succeeded **"
     else
       util::print::error "** GO Test Failed **"

--- a/language-family/scripts/.util/print.sh
+++ b/language-family/scripts/.util/print.sh
@@ -36,7 +36,8 @@ function util::print::success() {
   reset="\033[0;39m"
 
   echo -e "${green}${message}${reset}" >&2
-  exit 0
+  exitcode="${2:-0}"
+  exit "${exitcode}"
 }
 
 function util::print::warn() {

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -130,3 +130,13 @@ function util::tools::packager::install () {
         GOBIN="${dir}" go get github.com/cloudfoundry/libcfbuildpack/packager
     fi
 }
+
+function util::tools::tests::checkfocus() {
+  testout="${1}"
+  if grep -q 'Focused: [1-9]' "${testout}"; then
+    echo "Detected Focused Test(s) - setting exit code to 197"
+    rm "${testout}"
+    util::print::success "** GO Test Succeeded **" 197
+  fi
+  rm "${testout}"
+}

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -97,8 +97,11 @@ function images::pull() {
 
 function tests::run() {
   util::print::title "Run Buildpack Runtime Integration Tests"
+
+  testout=$(mktemp)
   pushd "${BUILDPACKDIR}" > /dev/null
-    if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration; then
+    if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${testout}"; then
+      util::tools::tests::checkfocus "${testout}"
       util::print::success "** GO Test Succeeded **"
     else
       util::print::error "** GO Test Failed **"


### PR DESCRIPTION
These tests are used to validate pull requests and it's
very easy to overlook focused tests and assume the change
in PR satisfies the entire test suite.

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>