### PR TITLE
actions/pr/open: validate response before counting

### DIFF
--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -48,12 +48,20 @@ function pr::open() {
   body="${3}"
   branch="${4}"
   org="$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f1)"
-  count="$(
+
+  response="$(
     curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?head=${org}:${branch}" \
       -H "Authorization: token ${token}" \
-      --silent \
-      | jq -r 'length'
+      --silent
   )"
+
+  if [[ "${response}" == *"message"* ]];then
+    echo "Github API request failed with the following message:"
+    echo "${response}"
+    exit 1
+  fi
+
+  count="$(echo "${response}" | jq -r 'length')"
 
   if [[ "${count}" != "0" ]]; then
     echo "PR already exists, updated with new commit."


### PR DESCRIPTION
If the token in invalid, github api responds with the following:
```
{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest"
}
```

The length of above is "2" and could be misinterpreted as
2 existing pull requests. Therefore, check for error message
before counting the length.

E.g. of bug in action:
https://github.com/sophiewigmore/full-builder/actions/runs/284409623