### PR TITLE
Build position-independent executables

### DIFF
--- a/implementation/scripts/build.sh
+++ b/implementation/scripts/build.sh
@@ -49,6 +49,7 @@ function run::build() {
 
       GOOS=linux \
         go build \
+          -buildmode=pie \
           -ldflags="-s -w" \
           -o "run" \
             "${BUILDPACKDIR}/run"
@@ -81,6 +82,7 @@ function cmd::build() {
 
       GOOS="linux" \
         go build \
+          -buildmode=pie \
           -ldflags="-s -w" \
           -o "${BUILDPACKDIR}/bin/${name}" \
             "${src}/main.go"


### PR DESCRIPTION
Seems to help with resolving upx-compressed binaries that experience segmentation faults on invocation.