### PR TITLE
integration.sh: flag to dump test time variables to a file

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -18,6 +18,11 @@ source "${PROGDIR}/.util/git.sh"
 function main() {
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
+      --dump|-d)
+        dumpfile="${2}"
+        shift 2
+        ;;
+
       --help|-h)
         shift 1
         usage
@@ -51,7 +56,8 @@ integration.sh [OPTIONS]
 Runs the integration test suite.
 
 OPTIONS
-  --help  -h  prints the command usage
+  --help        -h        prints the command usage
+  --dump <file> -d <file> dumps test environment info into file
 USAGE
 }
 
@@ -104,6 +110,11 @@ function images::pull() {
 
   util::print::title "Pulling lifecycle image..."
   docker pull "${lifecycle_image}"
+
+  if [[ -n "${dumpfile:-}" ]]; then
+    util::tools::tests::dump "${dumpfile}" "${builder}" "${run_image}" \
+      "${lifecycle_image}"
+  fi
 }
 
 function token::fetch() {

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -131,6 +131,16 @@ function util::tools::packager::install () {
     fi
 }
 
+function util::tools::image::reference() {
+  local image digest
+  image="${1}"
+  digest="$(
+    docker inspect --format='{{index .RepoDigests 0}}' "${image}" \
+      | cut -d '@' -f 2
+  )"
+  echo "${image}@${digest}"
+}
+
 function util::tools::tests::checkfocus() {
   testout="${1}"
   if grep -q 'Focused: [1-9]' "${testout}"; then
@@ -139,4 +149,22 @@ function util::tools::tests::checkfocus() {
     util::print::success "** GO Test Succeeded **" 197
   fi
   rm "${testout}"
+}
+
+function util::tools::tests::dump() {
+  local output_file builder run lifecycle json
+  output_file="${1}"
+  builder="$(util::tools::image::reference "${2}")"
+  run="$(util::tools::image::reference "${3}")"
+  lifecycle="$(util::tools::image::reference "${4}")"
+
+  json="$(
+    jq -n \
+      --arg builder "${builder}" \
+      --arg run "${run}" \
+      --arg lifecycle "${lifecycle}" \
+      --arg pack_version "$(pack --version)" \
+      '{builder: $builder, run: $run, lifecycle: $lifecycle, pack: $pack_version}' \
+  )"
+  echo "${json}" > "${output_file}"
 }

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -14,6 +14,11 @@ source "${PROGDIR}/.util/print.sh"
 function main() {
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
+      --dump|-d)
+        dumpfile="${2}"
+        shift 2
+        ;;
+
       --help|-h)
         shift 1
         usage
@@ -46,7 +51,8 @@ integration.sh [OPTIONS]
 Runs the integration test suite.
 
 OPTIONS
-  --help  -h  prints the command usage
+  --help        -h        prints the command usage
+  --dump <file> -d <file> dumps test environment info into file
 USAGE
 }
 
@@ -93,6 +99,11 @@ function images::pull() {
 
   util::print::title "Pulling lifecycle image..."
   docker pull "${lifecycle_image}"
+
+  if [[ -n "${dumpfile:-}" ]]; then
+    util::tools::tests::dump "${dumpfile}" "${builder}" "${run_image}" \
+      "${lifecycle_image}"
+  fi
 }
 
 function tests::run() {


### PR DESCRIPTION
This may be stored with the buildpack or in the release notes if desired.

See example that uses the optional --dump flag:

```sh
$ ./scripts/integration.sh --dump /tmp/dump.json
$ cat /tmp/dump.json
{
  "builder": "index.docker.io/paketobuildpacks/builder:base@sha256:bae0a6b7ec5d51867eb49ac598775bb5fa8788bba458d2edfda314611be554a8",
  "run": "index.docker.io/paketobuildpacks/run:base-cnb@sha256:155ee4b4389fa88b8b9bd5444601417218b3da44e491b1aad8c8b6c2365e7909",
  "lifecycle": "index.docker.io/buildpacksio/lifecycle:0.9.3@sha256:bc253af2edf1577717618cb3a95f0f16bb18fc9e804efbcc1b85f657d931a757",
  "pack": "0.14.2+git-0fd189d.build-1450"
}
```