### PR TITLE
Don't trigger update buildpack.toml workflow on push

### DIFF
--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -3,9 +3,6 @@ name: Update buildpack.toml
 on:
   schedule:
   - cron: '*/15 * * * *'
-  push:
-    branches:
-    - main
 
 jobs:
   update-buildpack-toml:


### PR DESCRIPTION
## Summary
Removes the `push` event trigger than was left in the workflow for testing purposes. This workflow should only trigger on a schedule.

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
