### PR TITLE
Allows schedules workflows to be manually triggered

### DIFF
--- a/implementation/.github/workflows/update-github-config.yml
+++ b/implementation/.github/workflows/update-github-config.yml
@@ -3,6 +3,7 @@ name: Update shared github-config
 on:
   schedule:
   - cron: '*/15 * * * *'
+  workflow_dispatch: {}
 
 jobs:
   build:

--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -3,6 +3,7 @@ name: Update buildpack.toml
 on:
   schedule:
   - cron: '*/15 * * * *'
+  workflow_dispatch: {}
 
 jobs:
   update-buildpack-toml:

--- a/language-family/.github/workflows/update-github-config.yml
+++ b/language-family/.github/workflows/update-github-config.yml
@@ -3,6 +3,7 @@ name: Update shared github-config
 on:
   schedule:
   - cron: '*/15 * * * *'
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Including `workflow_dispatch` as an event trigger on these scheduled workflows will allow us to trigger them manually on demand. On the `Actions` page, the manual trigger looks like this:

![Screen Shot 2020-12-15 at 11 39 19 AM](https://user-images.githubusercontent.com/155736/102264269-3fd26100-3eca-11eb-808c-5cbcd5953179.png)


## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
