### PR TITLE
impl/scripts: install jam whether packit compliant or not

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -59,11 +59,10 @@ function tools::install() {
   util::tools::pack::install \
     --directory "${BUILDPACKDIR}/.bin"
 
-  if [[ -f "${BUILDPACKDIR}/.packit" ]]; then
-    util::tools::jam::install \
-      --directory "${BUILDPACKDIR}/.bin"
+  util::tools::jam::install \
+    --directory "${BUILDPACKDIR}/.bin"
 
-  else
+  if [[ ! -f "${BUILDPACKDIR}/.packit" ]]; then
     util::tools::packager::install \
       --directory "${BUILDPACKDIR}/.bin"
   fi


### PR DESCRIPTION
Newer occam/freezer uses the jam cli directly
See https://github.com/ForestEckhardt/freezer/compare/v0.0.3...v0.0.5