### PR TITLE
add the --use-token flag to implementation integration.sh

### DIFF
--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
     - name: Run Integration Tests
-      run: ./scripts/integration.sh
+      run: ./scripts/integration.sh --use-token
       env:
         GIT_TOKEN: ${{ github.token }}
 

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -37,7 +37,7 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 
     - name: Run Integration Tests
-      run: ./scripts/integration.sh
+      run: ./scripts/integration.sh --use-token
       env:
         GIT_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

When running the integration tests in the implementation buildpacks workflows, use the `--use-token` flag to avoid rate limiting.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
