### PR TITLE
Refactors sync action to only perform rsync

### DIFF
--- a/actions/sync/action.yml
+++ b/actions/sync/action.yml
@@ -1,38 +1,22 @@
 name: 'Sync'
 
 description: |
-  Copies a fixed path from the source repo to the root of the repo
-  that uses this action, then sends a PR against the repo's main branch
-inputs:
-  config-repo:
-    description: 'Path to checked out repo with shared files'
-    required: true
-  current-repo:
-    description: 'Path to this repo checkout out'
-    required: true
-  config-path:
-    description: 'Path inside config repo that maps to the current repo'
-    required: true
-  ssh-private-key:
-    description: 'Private SSH key to push to the current repo'
-    required: true
-  current-path:
-    description: 'Path inside the current repo to copy into'
-    default: ''
+  Syncs directories between a shared github-config repo and a buildpack repo
 
-outputs: {}
+inputs:
+  workspace:
+    description: 'Path to the workspace to sync into'
+    required: true
+
+  config:
+    description: 'Path to the github-config directory to sync'
+    required: true
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - --config-repo
-  - ${{ inputs.config-repo }}
-  - --current-repo
-  - ${{ inputs.current-repo}}
-  - --config-path
-  - ${{ inputs.config-path }}
-  - --ssh-private-key
-  - ${{ inputs.ssh-private-key }}
-  - --current-path
-  - ${{ inputs.current-path }}
+  - --workspace
+  - ${{ inputs.workspace }}
+  - --config
+  - ${{ inputs.config }}

--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -5,32 +5,17 @@ set -u
 set -o pipefail
 
 function main() {
-  local config_repo current_repo config_path ssh_private_key current_path branch
+  local workspace config
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
-      --config-repo)
-        config_repo="${GITHUB_WORKSPACE}/${2}"
+      --workspace)
+        workspace="${2}"
         shift 2
         ;;
 
-      --current-repo)
-        current_repo="${GITHUB_WORKSPACE}/${2}"
-        shift 2
-        ;;
-
-      --config-path)
-        config_path="${2}"
-        shift 2
-        ;;
-
-      --ssh-private-key)
-        ssh_private_key="${2}"
-        shift 2
-        ;;
-
-      --current-path)
-        current_path="${2}"
+      --config)
+        config="${2}"
         shift 2
         ;;
 
@@ -40,148 +25,33 @@ function main() {
     esac
   done
 
-  branch="automation/github-config/update"
-
-  validate "${config_repo}" "${current_repo}" "${config_path}"
-  checkout_pr_branch "${current_repo}" "${branch}"
-  sync_dirs "${config_repo}" "${current_repo}" "${config_path}" "${current_path}"
-  if [ "$(check_for_updates "${current_repo}")" = 0 ]; then
-    echo "nothing to sync"
-  else
-    commit_and_push "${current_repo}" "${ssh_private_key}" "${branch}" "${config_repo}"
-    open_pr "${branch}"
-  fi
-}
-
-function validate() {
-  local rc config_repo current_repo config_path
-  rc=0
-  config_repo="${1}"
-  current_repo="${2}"
-  config_path="${3}"
-
-  if [ ! -d "${config_repo}/.git" ]; then
-    echo "src-repo ${config_repo} is not a valid git repository"; rc=1;
-  fi
-
-  if [ ! -d "${current_repo}/.git" ]; then
-    echo "this-repo ${current_repo} is not a valid git repository"; rc=1;
-  fi
-
-  if [ ! -d "${config_repo}/${config_path}" ]; then
-    echo "src-path ${config_path} is not a valid path inside src-repo"; rc=1;
-  fi
-
-  if [ "${rc}" -ne 0 ]; then
-    exit 1
-  fi
-}
-
-function checkout_pr_branch() {
-  local current_repo branch
-  current_repo="${1}"
-  branch="${2}"
-
-  git -C "${current_repo}" fetch origin
-
-  if git -C "${current_repo}" branch -a | grep "${branch}"; then
-    git -C "${current_repo}" checkout -b "${branch}" "origin/${branch}"
-
-    git -C "${current_repo}" pull -r
-  else
-    git -C "${current_repo}" checkout -b "${branch}"
-  fi
-}
-
-function sync_dirs() {
-  local config_repo current_repo config_path current_path
-  config_repo="${1}"
-  current_repo="${2}"
-  config_path="${3}"
-  current_path="${4}"
-
-
-  pushd "${config_repo}/${config_path}" > /dev/null
-    for dir in $(ls -Ap . | grep "/"); do
-      if [[ -f "${current_repo}/${current_path}/${dir}/.syncignore" ]]; then
-        rsync \
-          -r -v -c "${dir}" \
-          "${current_repo}/${current_path}/${dir}" \
-          --delete \
-          --exclude=".syncignore" \
-          --exclude-from="${current_repo}/${current_path}/${dir}/.syncignore"
-      else
-        rsync \
-          -r -v -c "${dir}" \
-          "${current_repo}/${current_path}/${dir}" \
-          --delete
-      fi
-    done
+  pushd "${config}" > /dev/null
+    IFS=" " read -r -a directories < <(find . -type d -depth 1 -print0 | xargs -0)
   popd > /dev/null
-}
 
-function check_for_updates() {
-  local current_repo num_changes
-  current_repo="${1}"
+  for dir in "${directories[@]}"; do
+    local src dest
+    src="$( cd "${config}/${dir}" && pwd)/"
+    dest="$(cd "${workspace}/${dir}" && pwd)/"
 
-  pushd "${current_repo}" > /dev/null
-    num_changes=$( git status --porcelain=v1 2>/dev/null | wc -l)
-    echo $num_changes
-  popd > /dev/null
-}
+    echo "syncing from ${src} to ${dest}"
 
+    if [[ -f "${dest}/.syncignore" ]]; then
+      rsync \
+        -r -v -c "${src}" \
+        "${dest}" \
+        --delete \
+        --exclude=".syncignore" \
+        --exclude-from="${dest}/.syncignore"
+    else
+      rsync \
+        -r -v -c "${src}" \
+        "${dest}" \
+        --delete
+    fi
 
-function commit_and_push() {
-  local current_repo ssh_private_key branch config_repo sha
-  current_repo="${1}"
-  ssh_private_key="${2}"
-  branch="${3}"
-  config_repo="${4}"
-
-  sha="$(git -C "${config_repo}" rev-parse --short HEAD)"
-
-  pushd "${current_repo}" > /dev/null
-    git config user.email "paketobuildpacks@paketo.io"
-    git config user.name "paketo-bot"
-    git add --all .
-    git commit --message "Update github-config to ${sha}"
-    git remote add origin-ssh "git@github.com:${GITHUB_REPOSITORY}.git"
-
-    eval "$(ssh-agent)"
-    echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
-
-    echo "${ssh_private_key}" | ssh-add -
-
-    git push origin-ssh "${branch}"
-  popd > /dev/null
-}
-
-function open_pr() {
-  local branch org
-  branch="${1}"
-  org="$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f1)"
-
-  local count
-  count="$(
-    curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?head=${org}:${branch}" \
-      -H "Authorization: token ${GITHUB_TOKEN}" \
-      --silent \
-      | jq -r 'length'
-  )"
-
-  if [[ "${count}" != "0" ]]; then
-    echo "PR already exists, updated with new commit."
-    return
-  fi
-
-  curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls" \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -X POST \
-    --data '{
-      "head": "'"${branch}"'",
-      "base": "main",
-      "title": "Update shared github-config"
-    }'
+    echo
+  done
 }
 
 main "${@:-}"

--- a/implementation/.github/workflows/update-github-config.yml
+++ b/implementation/.github/workflows/update-github-config.yml
@@ -11,25 +11,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    # checkout paketo github-config as src-repo
-    - name: Checkout paketo github-config repo
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Checkout github-config
       uses: actions/checkout@v2
       with:
         repository: paketo-buildpacks/github-config
-        path: config-repo
+        path: github-config
 
-    # checkout this repo
-    - name: Checkout
-      uses: actions/checkout@v2
+    - name: Checkout Branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
       with:
-        path: current-repo
+        branch: automation/github-config/update
 
     - name: Run the sync action
       uses: paketo-buildpacks/github-config/actions/sync@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       with:
-        config-repo: config-repo
-        current-repo: current-repo
-        config-path: "/implementation"
-        ssh-private-key: ${{ secrets.PAKETO_BOT_SSH_KEY }}
+        workspace: ${{ github.workspace }}
+        config: "${{ github.workspace }}/github-config/implementation"
+
+    - name: Cleanup
+      run: rm -rf github-config
+
+    - name: Commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating github-config"
+        pathspec: "."
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/github-config/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updates github-config"
+        branch: automation/github-config/update

--- a/language-family/.github/workflows/update-github-config.yml
+++ b/language-family/.github/workflows/update-github-config.yml
@@ -11,25 +11,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    # checkout paketo github-config as src-repo
-    - name: Checkout paketo github-config repo
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Checkout github-config
       uses: actions/checkout@v2
       with:
         repository: paketo-buildpacks/github-config
-        path: config-repo
+        path: github-config
 
-    # checkout this repo
-    - name: Checkout
-      uses: actions/checkout@v2
+    - name: Checkout Branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
       with:
-        path: current-repo
+        branch: automation/github-config/update
 
     - name: Run the sync action
       uses: paketo-buildpacks/github-config/actions/sync@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       with:
-        config-repo: config-repo
-        current-repo: current-repo
-        config-path: "/language-family"
-        ssh-private-key: ${{ secrets.PAKETO_BOT_SSH_KEY }}
+        workspace: ${{ github.workspace }}
+        config: "${{ github.workspace }}/github-config/language-family"
+
+    - name: Cleanup
+      run: rm -rf github-config
+
+    - name: Commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating github-config"
+        pathspec: "."
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/github-config/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updates github-config"
+        branch: automation/github-config/update


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The sync action can be reduced to simply performing the `rsync` of the shared files between the `github-config` repo and the buildpack repo. We can reuse all of the existing `pull-request/*` actions to replace everything else that this workflow needs.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
