### PR TITLE
optionally load GPG key for paketo bot before committing

### DIFF
--- a/actions/pull-request/create-commit/action.yml
+++ b/actions/pull-request/create-commit/action.yml
@@ -12,6 +12,14 @@ inputs:
   pathspec:
     description: 'Git pathspec to stage'
     required: true
+  keyid:
+    description: 'ID of GPG signing key to use for signed commit'
+    required: false
+    default: ''
+  key:
+    description: 'GPG signing key to use for signed commit'
+    required: false
+    default: ''
 
 outputs:
   commit_sha:
@@ -25,3 +33,7 @@ runs:
   - ${{ inputs.message }}
   - "--pathspec"
   - ${{ inputs.pathspec }}
+  - "--keyid"
+  - ${{ inputs.keyid }}
+  - "--key"
+  - ${{ inputs.key }}

--- a/actions/pull-request/create-commit/entrypoint
+++ b/actions/pull-request/create-commit/entrypoint
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 function main() {
-  local message pathspec
+  local message pathspec keyid key
   while [ "${#}" != 0 ]; do
     case "${1}" in
       --message)
@@ -14,6 +14,16 @@ function main() {
 
       --pathspec)
         pathspec="${2}"
+        shift 2
+        ;;
+
+      --keyid)
+        keyid="${2}"
+        shift 2
+        ;;
+
+      --key)
+        key="${2}"
         shift 2
         ;;
 
@@ -27,12 +37,22 @@ function main() {
     esac
   done
 
+  if [ -n "$keyid" ] && [ -n "$key" ]; then
+    mkdir -p ~/.gnupg/
+    printf "%s" "$key" | base64 --decode > ~/.gnupg/private.key
+    gpg --import ~/.gnupg/private.key
+
+    git config --global user.signingkey "$keyid"
+    git config --global commit.gpgsign true
+  fi
+
   git config --global user.email "paketobuildpacks@gmail.com"
   git config --global user.name "paketo-bot"
 
   if [[ -n "$(git status --short -- "${pathspec}")" ]]; then
     git add --all "${pathspec}"
     git commit --message "${message}"
+
     echo "::set-output name=commit_sha::$(git rev-parse HEAD)"
     exit 0
   fi


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Accepts GPG signing key and keyid as optional arguments to the commit action so that paketo-bot commits can be "verified".

Workflows will need to be updated to provide GPG_SIGNING_KEY and key ID secrets to use the signing capability.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will allow paketo-bot PRs to pass the verification check introduced in #219 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
