### PR TITLE
add manual trigger to builder update workflow

### DIFF
--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -3,6 +3,7 @@ name: Update builder.toml and Send Pull Request
 on:
   schedule:
   - cron: '*/15 * * * *'
+  workflow_dispatch: {}
 
 jobs:
   update:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
I added a manual trigger to the builder update workflow for the builder repos

## Use Cases
<!-- An explanation of the use cases your change enables -->
Sometimes GHA doesn't strictly follow the cron schedule. It'd be nice to kick off a builder update manually if there's an update we want to get out quickly, rather than waiting around for a scheduled job.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
