### PR TITLE
Allows builders to be bootstrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ github repo has recommended settings.
 
 If you just wrote a new CNB, run [bootstrap.sh](scripts/bootstrap.sh) as follows:
 ```sh
-# type is either "implementation" or "language-family"
-./scripts/bootstrap.sh <path/to/your/cnb> <type>
+# type is either "implementation", "language-family", or "builder"
+./scripts/bootstrap.sh --target <path/to/your/cnb> --repo-type <type>
 ```
 
 This will copy the relevant config files to your CNB. Git commit and Push your CNB.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ source "${ROOT_DIR}/scripts/.util/print.sh"
 source "${ROOT_DIR}/scripts/sanity.sh"
 
 function main() {
-  local target buildpack_type
+  local target repo_type
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
@@ -21,8 +21,8 @@ function main() {
         shift 2
         ;;
 
-      --buildpack-type)
-        buildpack_type="${2}"
+      --repo-type)
+        repo_type="${2}"
         shift 2
         ;;
 
@@ -48,43 +48,43 @@ function main() {
     util::print::error "--target is a required flag"
   fi
 
-  if [[ -z "${buildpack_type:-}" ]]; then
+  if [[ -z "${repo_type:-}" ]]; then
     usage
     echo
-    util::print::error "--buildpack-type is a required flag"
+    util::print::error "--repo-type is a required flag"
   fi
 
   sanity::check "${ROOT_DIR}"
-  bootstrap "${target}" "${buildpack_type}"
+  bootstrap "${target}" "${repo_type}"
 }
 
 function usage() {
   cat <<-USAGE
-bootstrap.sh --target <target> --buildpack-type <buildpack-type> [OPTIONS]
+bootstrap.sh --target <target> --repo-type <repo-type> [OPTIONS]
 
-Bootstraps a buildpack repository with github configuration and scripts.
+Bootstraps a repository with github configuration and scripts.
 
 OPTIONS
-  --buildpack-type <buildpack-type>  type of buildpack (implementation|language-family)
-  --help  -h                         prints the command usage
-  --target <target>                  path to a buildpack repository
+  --repo-type <repo-type>  type of repo (implementation|language-family|builder)
+  --help  -h               prints the command usage
+  --target <target>        path to a buildpack repository
 USAGE
 }
 
 function bootstrap() {
-  local target buildpack_type
+  local target repo_type
   target="${1}"
-  buildpack_type="${2}"
+  repo_type="${2}"
 
   if [[ ! -d "${target}" ]]; then
     util::print::error "cannot bootstrap: \"${target}\" does not exist"
   fi
 
-  if [[ "${buildpack_type}" != "implementation" && "${buildpack_type}" != "language-family" ]]; then
-    util::print::error "cannot bootstrap: \"${buildpack_type}\" is not a valid buildpack type"
+  if [[ "${repo_type}" != "implementation" && "${repo_type}" != "language-family" && "${repo_type}" != "builder" ]]; then
+    util::print::error "cannot bootstrap: \"${repo_type}\" is not a valid repo type"
   fi
 
-  cp -pR "${ROOT_DIR}/${buildpack_type}/." "${target}"
+  cp -pR "${ROOT_DIR}/${repo_type}/." "${target}"
 }
 
 main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The `./scripts/bootstrap.sh` script should also support builder repos. This is helpful if we ever need to manually sync the repo GitHub config.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
