### PR TITLE
Builders should update from the right location

### DIFF
--- a/builder/.github/workflows/update-github-config.yml
+++ b/builder/.github/workflows/update-github-config.yml
@@ -31,7 +31,7 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/sync@sync-action
       with:
         workspace: /github/workspace
-        config: /github/workspace/github-config/implementation
+        config: /github/workspace/github-config/builder
 
     - name: Cleanup
       run: rm -rf github-config


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes the typo that caused builders to update from the implementation directory.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
