### PR TITLE
sign commits in workflows that make paketo bot commits

### DIFF
--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -27,6 +27,8 @@ jobs:
       with:
         message: "Update builder.toml"
         pathspec: "builder.toml"
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Git push
       if: ${{ steps.commit.outputs.commit_sha != '' }}

--- a/builder/.github/workflows/update-github-config.yml
+++ b/builder/.github/workflows/update-github-config.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         message: "Updating github-config"
         pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}

--- a/implementation/.github/workflows/update-github-config.yml
+++ b/implementation/.github/workflows/update-github-config.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         message: "Updating github-config"
         pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}

--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -28,6 +28,8 @@ jobs:
       with:
         message: "Updating buildpacks in buildpack.toml"
         pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}

--- a/language-family/.github/workflows/update-github-config.yml
+++ b/language-family/.github/workflows/update-github-config.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         message: "Updating github-config"
         pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}


### PR DESCRIPTION
Signed-off-by: Forest Eckhardt <feckhardt@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Now, bot PRs opened by paketo-bot will be verified. These PRs will pass our check for unverified commits and should automerge (once again).

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
