### PR TITLE
fixes create-commit action to install tool for signing

### DIFF
--- a/actions/pull-request/create-commit/Dockerfile
+++ b/actions/pull-request/create-commit/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine
 RUN apk add \
     bash \
     git \
+    gnupg \
   && rm -rf /var/cache/apk/*
 
 COPY entrypoint /entrypoint

--- a/actions/pull-request/create-commit/entrypoint
+++ b/actions/pull-request/create-commit/entrypoint
@@ -39,8 +39,9 @@ function main() {
 
   if [ -n "$keyid" ] && [ -n "$key" ]; then
     mkdir -p ~/.gnupg/
-    printf "%s" "$key" | base64 --decode > ~/.gnupg/private.key
-    gpg --import ~/.gnupg/private.key
+    printf "quiet" > ~/.gnupg/options
+    printf "%s" "$key" | base64 -d > ~/.gnupg/private.key
+    gpg --options ~/.gnupg/options --import ~/.gnupg/private.key
 
     git config --global user.signingkey "$keyid"
     git config --global commit.gpgsign true


### PR DESCRIPTION
also adds 'quiet' config to gpg key import

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->
Fixes a bug where commits can't be signed because `gpg` isn't installed and incorrect flag used for `base64`. Also configures `gpg` to install the key quietly.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
