### PR TITLE
Parameterizes committer name and email in create-commit action

### DIFF
--- a/actions/pull-request/create-commit/action.yml
+++ b/actions/pull-request/create-commit/action.yml
@@ -12,6 +12,14 @@ inputs:
   pathspec:
     description: 'Git pathspec to stage'
     required: true
+  committer_name:
+    description: 'Name of the committer'
+    required: false
+    default: 'paketo-bot'
+  committer_email:
+    description: 'Email of the committer'
+    required: false
+    default: 'paketobuildpacks@gmail.com'
   keyid:
     description: 'ID of GPG signing key to use for signed commit'
     required: false
@@ -33,6 +41,10 @@ runs:
   - ${{ inputs.message }}
   - "--pathspec"
   - ${{ inputs.pathspec }}
+  - "--committer-name"
+  - ${{ inputs.committer_name }}
+  - "--committer-email"
+  - ${{ inputs.committer_email }}
   - "--keyid"
   - ${{ inputs.keyid }}
   - "--key"

--- a/actions/pull-request/create-commit/entrypoint
+++ b/actions/pull-request/create-commit/entrypoint
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 function main() {
-  local message pathspec keyid key
+  local message pathspec committer_name committer_email keyid key
   while [ "${#}" != 0 ]; do
     case "${1}" in
       --message)
@@ -14,6 +14,16 @@ function main() {
 
       --pathspec)
         pathspec="${2}"
+        shift 2
+        ;;
+
+      --committer-name)
+        committer_name="${2}"
+        shift 2
+        ;;
+
+      --committer-email)
+        committer_email="${2}"
         shift 2
         ;;
 
@@ -47,8 +57,8 @@ function main() {
     git config --global commit.gpgsign true
   fi
 
-  git config --global user.email "paketobuildpacks@gmail.com"
-  git config --global user.name "paketo-bot"
+  git config --global user.name "${committer_name}"
+  git config --global user.email "${committer_email}"
 
   if [[ -n "$(git status --short -- "${pathspec}")" ]]; then
     git add --all "${pathspec}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The committer name and email can now be overridden in a workflow. The defaults will remain what their hardcoded values were originally, which should mean that we won't need to update any existing workflow references.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This allows other to reuse this action with their own bot.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
