### PR TITLE
Updates gh in actions to 1.7.0

### DIFF
--- a/actions/pull-request/approve/Dockerfile
+++ b/actions/pull-request/approve/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add \
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-ARG gh_version=0.11.1
+ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \

--- a/actions/pull-request/approve/action.yml
+++ b/actions/pull-request/approve/action.yml
@@ -4,28 +4,18 @@ description: |
   Conditionally auto-approves PRs based on a set of rules
 
 inputs:
-  user:
-    description: 'User account to use when approving'
-    required: true
   token:
     description: 'Token used to authenticate user account'
     required: true
   number:
     description: 'PR number'
     required: true
-  author:
-    description: 'PR author'
-    required: true
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - "--user"
-  - ${{ inputs.user }}
   - "--token"
   - ${{ inputs.token }}
   - "--number"
   - ${{ inputs.number }}
-  - "--author"
-  - ${{ inputs.author }}

--- a/actions/pull-request/approve/entrypoint
+++ b/actions/pull-request/approve/entrypoint
@@ -4,15 +4,10 @@ set -eu
 set -o pipefail
 
 function main() {
-  local user token number author
+  local token number
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
-      --user)
-        user="${2}"
-        shift 2
-        ;;
-
       --token)
         token="${2}"
         shift 2
@@ -20,11 +15,6 @@ function main() {
 
       --number)
         number="${2}"
-        shift 2
-        ;;
-
-      --author)
-        author="${2}"
         shift 2
         ;;
 
@@ -38,70 +28,9 @@ function main() {
     esac
   done
 
-  if rules::check "${author}"; then
-    review::approve "${user}" "${token}" "${number}"
-  fi
-}
-
-function rules::check() {
-  local author
-  author="${1}"
-
-  echo "Checking rules:"
-
-  if rules::author::dependabot "${author}"; then
-    return 0
-  fi
-
-  if rules::author::paketobot "${author}"; then
-    return 0
-  fi
-
-  echo "fail: no rules passed"
-  return 1
-}
-
-function rules::author::dependabot() {
-  local author
-  author="${1}"
-
-  if [[ "${author}" == "dependabot[bot]" ]]; then
-    echo "  pass: author is dependabot[bot]"
-    return 0
-  fi
-
-  echo "  fail: author is not dependabot[bot]"
-  return 1
-}
-
-function rules::author::paketobot() {
-  local author
-  author="${1}"
-
-  if [[ "${author}" == "paketo-bot" ]]; then
-    echo "  pass: author is paketo-bot"
-    return 0
-  fi
-
-  echo "  fail: author is not paketo-bot"
-  return 1
-}
-
-function review::approve() {
-  local user token number
-  user="${1}"
-  token="${2}"
-  number="${3}"
+  echo "${token}" | gh auth login --with-token
 
   echo "Approving PR ${number}"
-
-  mkdir -p "${HOME}/.config/gh"
-  cat <<-EOF > "${HOME}/.config/gh/hosts.yml"
----
-github.com:
-  user: ${user}
-  oauth_token: ${token}
-EOF
 
   pushd "${GITHUB_WORKSPACE}" > /dev/null || true
     gh pr review "${number}" --approve

--- a/actions/pull-request/merge/Dockerfile
+++ b/actions/pull-request/merge/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add \
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-ARG gh_version=0.11.1
+ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \

--- a/actions/pull-request/merge/action.yml
+++ b/actions/pull-request/merge/action.yml
@@ -4,9 +4,6 @@ description: |
   Merges PRs
 
 inputs:
-  user:
-    description: 'User account to use when approving'
-    required: true
   token:
     description: 'Token used to authenticate user account'
     required: true
@@ -18,8 +15,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - "--user"
-  - ${{ inputs.user }}
   - "--token"
   - ${{ inputs.token }}
   - "--number"

--- a/actions/pull-request/merge/entrypoint
+++ b/actions/pull-request/merge/entrypoint
@@ -4,15 +4,10 @@ set -eu
 set -o pipefail
 
 function main() {
-  local user token number
+  local token number
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
-      --user)
-        user="${2}"
-        shift 2
-        ;;
-
       --token)
         token="${2}"
         shift 2
@@ -33,24 +28,9 @@ function main() {
     esac
   done
 
-  pr::merge "${user}" "${token}" "${number}"
-}
-
-function pr::merge() {
-  local user token number
-  user="${1}"
-  token="${2}"
-  number="${3}"
+  echo "${token}" | gh auth login --with-token
 
   echo "Merging PR ${number}"
-
-  mkdir -p "${HOME}/.config/gh"
-  cat <<-EOF > "${HOME}/.config/gh/hosts.yml"
----
-github.com:
-  user: ${user}
-  oauth_token: ${token}
-EOF
 
   pushd "${GITHUB_WORKSPACE}" > /dev/null || true
     gh pr merge "${number}" --rebase --delete-branch=false

--- a/actions/pull-request/open/Dockerfile
+++ b/actions/pull-request/open/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add \
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-ARG gh_version=1.0.0
+ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \

--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -38,16 +38,6 @@ function main() {
     esac
   done
 
-  pr::open "${token}" "${title}" "${body}" "${branch}"
-}
-
-function pr::open() {
-  local token title body branch
-  token="${1}"
-  title="${2}"
-  body="${3}"
-  branch="${4}"
-
   echo "${token}" | gh auth login --with-token
 
   count="$(gh pr list --repo "${GITHUB_REPOSITORY}" \

--- a/actions/pull-request/rebase/Dockerfile
+++ b/actions/pull-request/rebase/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add \
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-ARG gh_version=0.11.1
+ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \

--- a/actions/pull-request/rebase/action.yml
+++ b/actions/pull-request/rebase/action.yml
@@ -4,9 +4,6 @@ description: |
   Rebases a PR against the base branch
 
 inputs:
-  user:
-    description: 'User account to use when approving'
-    required: true
   token:
     description: 'Token used to authenticate user account'
     required: true
@@ -18,8 +15,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - "--user"
-  - ${{ inputs.user }}
   - "--token"
   - ${{ inputs.token }}
   - "--number"

--- a/actions/pull-request/rebase/entrypoint
+++ b/actions/pull-request/rebase/entrypoint
@@ -4,15 +4,10 @@ set -eu
 set -o pipefail
 
 function main() {
-  local user token number
+  local token number
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
-      --user)
-        user="${2}"
-        shift 2
-        ;;
-
       --token)
         token="${2}"
         shift 2
@@ -33,24 +28,9 @@ function main() {
     esac
   done
 
-  pr::rebase "${user}" "${token}" "${number}"
-}
-
-function pr::rebase() {
-  local user token number
-  user="${1}"
-  token="${2}"
-  number="${3}"
+  echo "${token}" | gh auth login --with-token
 
   echo "Rebasing PR ${number}"
-
-  mkdir -p "${HOME}/.config/gh"
-  cat <<-EOF > "${HOME}/.config/gh/hosts.yml"
----
-github.com:
-  user: ${user}
-  oauth_token: ${token}
-EOF
 
   pushd "${GITHUB_WORKSPACE}" > /dev/null || true
     gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}/update-branch" \

--- a/builder/.github/workflows/auto-merge.yml
+++ b/builder/.github/workflows/auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}
 
@@ -41,6 +40,5 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'behind' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/rebase@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}

--- a/builder/.github/workflows/test-pull-request.yml
+++ b/builder/.github/workflows/test-pull-request.yml
@@ -48,11 +48,9 @@ jobs:
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: actions/checkout@v2
 
-    - name: Auto Approve
+    - name: Approve
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
-        user: paketo-bot-reviewer
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        author: ${{ github.event.pull_request.user.login }}
         number: ${{ github.event.number }}

--- a/implementation/.github/workflows/auto-merge.yml
+++ b/implementation/.github/workflows/auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}
 
@@ -41,6 +40,5 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'behind' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/rebase@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -67,11 +67,9 @@ jobs:
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: actions/checkout@v2
 
-    - name: Auto Approve
+    - name: Approve
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
-        user: paketo-bot-reviewer
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        author: ${{ github.event.pull_request.user.login }}
         number: ${{ github.event.number }}

--- a/language-family/.github/workflows/auto-merge.yml
+++ b/language-family/.github/workflows/auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}
 
@@ -41,6 +40,5 @@ jobs:
       if: ${{ steps.pull_request.outputs.mergeable_state == 'behind' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/rebase@main
       with:
-        user: paketo-bot
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -49,11 +49,9 @@ jobs:
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: actions/checkout@v2
 
-    - name: Auto Approve
+    - name: Approve
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
-        user: paketo-bot-reviewer
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        author: ${{ github.event.pull_request.user.login }}
         number: ${{ github.event.number }}


### PR DESCRIPTION
- removes extra checks in approve action that are unneeded
- simplifies action APIs for actions using newer gh

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We have been using a rather old version of the `gh` CLI. This updates the actions that use `gh` to `v1.7.0`. Updating allows us to streamline the API for some of these actions to drop certain fields like `user` because the authentication can be performed with only a token.

Additionally, this includes the removal of a check in the `pull-request/approve` action that asserts bot PRs were opened by either `paketo-bot` or `dependabot[bot]`. This check is unnecessary because that is already checked earlier in the workflows that use this action. It also makes it easier to use this action outside of Paketo buildpacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
