### PR TITLE
fix pack installation in create release workflow to use tools.json

### DIFF
--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Get pack version
       id: pack-version
       run : |
-        echo "::set-output name=version::$(cat ./.github/pack-version)"
+        version=$(jq -r .pack "scripts/.util/tools.json")
+        echo "::set-output name=version::${version#v}"
 
     - name: Install Global Pack
       uses: buildpacks/github-actions/setup-pack@main


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Since [this change](https://github.com/paketo-buildpacks/github-config/commit/3e0e4cdd89ef38e20dd9a7165645d1d2c6add955) to the builders repo removed the `.github/pack-version` file and replaced it with `tools.json`, the Create Release workflow has been failing on the builders repos. (e.g. [this run](https://github.com/paketo-buildpacks/full-builder/runs/2228819401?check_suite_focus=true)) The change reads the pack version from the correct file location and outputs the version in the right form (`0.18.0`, not `v0.18.0`) to be accepted by the pack installation Github Action.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
