### PR TITLE
turn on update builder cron job

### DIFF
--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -1,8 +1,8 @@
 name: Update builder.toml and Send Pull Request
 
 on:
-  # schedule:
-  # - cron: '*/15 * * * *'
+  schedule:
+  - cron: '*/15 * * * *'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Previously, cron job to update builder was turned off because lifecycle version 0.11.0 had a significant bug that broke builds on GCP vms. Now that they've released lifecycle 0.11.1, which patches this bug, we're okay to allow the builders to pull the latest lifecycle image once again.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
