### PR TITLE
Uploads workflow event payload after tests for PRs

### DIFF
--- a/builder/.github/workflows/test-pull-request.yml
+++ b/builder/.github/workflows/test-pull-request.yml
@@ -22,6 +22,16 @@ jobs:
     - name: Run Smoke Tests
       run: ./scripts/smoke.sh
 
+  upload:
+    name: Upload Workflow Event Payload
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: event-payload
+        path: ${{ github.event_path }}
+
   approve:
     name: Approve Bot PRs
     if: ${{ github.event.pull_request.user.login == 'paketo-bot' || github.event.pull_request.user.login == 'dependabot[bot]' }}

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -41,6 +41,16 @@ jobs:
       env:
         GIT_TOKEN: ${{ github.token }}
 
+  upload:
+    name: Upload Workflow Event Payload
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: event-payload
+        path: ${{ github.event_path }}
+
   approve:
     name: Approve Bot PRs
     if: ${{ github.event.pull_request.user.login == 'paketo-bot' || github.event.pull_request.user.login == 'dependabot[bot]' }}

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -23,6 +23,16 @@ jobs:
     - name: Run Integration Tests
       run: ./scripts/integration.sh
 
+  upload:
+    name: Upload Workflow Event Payload
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: event-payload
+        path: ${{ github.event_path }}
+
   approve:
     name: Approve Bot PRs
     if: ${{ github.event.pull_request.user.login == 'paketo-bot' || github.event.pull_request.user.login == 'dependabot[bot]' }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Recently, we have been seeing PRs that are opened by Dependabot failing due to a token permissions issue when the Test PR workflows attempt to auto-approve the PR. Our understanding is that this behavior by GitHub is correct, but it breaks our current workflow for these types of PRs. We would like to move to a workflow that will work in all cases.

This PR is the start of an attempt to create a pair of workflows that work in conjunction to give us this outcome. First, the existing portions of the Test PR workflow will execute, then a subsequent workflow that is separate, and with elevated permissions will run to perform the step to auto-approve the bot PR. In order to pass details about the Test PR to the second workflow, we will need to upload that information to the workflow's artifact store. This PR does that for each of the Test PR workflows.

The next steps from this will be a follow-on PR that then creates a second workflow that can download this artifact and act on it to auto-approve the bot PR.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
