### PR TITLE
Always use latest patch of go 1.16

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Checkout
       uses: actions/checkout@v2
     - name: Check repo structure

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/builder/.github/workflows/test-pull-request.yml
+++ b/builder/.github/workflows/test-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run Unit Tests
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Checkout
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Checkout
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/language-family/.github/workflows/create-draft-release.yml
+++ b/language-family/.github/workflows/create-draft-release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Checkout
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.16.x
 
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
go 1.16 has a few bugs like https://golang.org/issue/44812
(cmd/go: 'go get' does not add missing hash to go.sum when ziphash file missing from cache)
that was fixed in 1.16.1.

Go.sum had to be recalculated for this which could possibly have a
connection with above bug:
https://github.com/paketo-buildpacks/php-composer/runs/2096238683?check_suite_focus=true#step:5:489

Also trying to make sure the following error is not due to a golang
issue since I can run it fine locally on go 1.16.3

https://github.com/paketo-buildpacks/php-web/runs/2410350544?check_suite_focus=true


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
