### PR TITLE
Removes extra runs block from release notes action

### DIFF
--- a/actions/release/notes/action.yml
+++ b/actions/release/notes/action.yml
@@ -3,10 +3,6 @@ name: 'Create Language Family Release Notes'
 description: |
   Creates release notes for a language family
 
-runs:
-  using: 'docker'
-  image: 'Dockerfile'
-
 inputs:
   repo:
     description: 'Repository that will have draft release reset'


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
I broke the action in #260 by including an extra `runs` block. I thought it was previously missing. This removes the extra block so that the action can run successfully.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
