### PR TITLE
don't increment tags that aren't semver versions

### DIFF
--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -32,7 +32,7 @@ main() {
   if [ -n "${current_version}" ]; then
     tag="${current_version}"
   else
-    previous="$(git describe --tags "$(git rev-list --tags --max-count=1)" || echo "v0.0.0")"
+    previous="$(git describe --tags --match "v[0-9]*" "$(git rev-list --tags --max-count=1)" || echo "v0.0.0")"
     tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
   fi
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When a repo has tags on it that don't look like `v1.2.3`, the increment-tag action would pick up on one of those other tags (if the most recent) and increment it. An example of this can be seen in [this failure on the dotnet core repo](https://github.com/paketo-buildpacks/dotnet-core/runs/2400967916?check_suite_focus=true), where we now automatically  tag `docs/v1.2.3` for each released `v1.2.3`. This change updates the action to only look for and increment standard version tags.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
