### PR TITLE
Remove duplicate entries in release changelog

### DIFF
--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -72,8 +72,9 @@ function main() {
           --header "Authorization: token ${token}" \
           --location \
           --silent \
-        | jq -r -S -c '.[] | select(.head.ref != "automation/github-config/update") | @text "* #\(.number): \(.title) *@\(.user.login)*"'
+        | jq -r -S -c '.[]'
       done \
+      | jq --slurp -r -S -c 'unique_by(.number) | .[] | select(.head.ref != "automation/github-config/update") | @text "* #\(.number): \(.title) *@\(.user.login)*"' \
       | sort -n
     )"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The current implementation may produce a changelog that has duplicate entries for some PRs that contain more than 1 commit. This change ensures that we only have one entry per PR.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
