### PR TITLE
Adds action and workflow to keep jam and pack updated

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -1,0 +1,77 @@
+---
+name: Update Tools
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Checkout Branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+      with:
+        branch: automation/tools/update
+
+    - name: Fetch Latest Jam
+      id: latest-jam
+      uses: paketo-buildpacks/github-config/actions/tools/latest@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        repo: paketo-buildpacks/packit
+
+    - name: Fetch Latest pack
+      id: latest-pack
+      uses: paketo-buildpacks/github-config/actions/tools/latest@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        repo: buildpacks/pack
+
+    - name: Update builder tools.json
+      env:
+        PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+      run: |
+        echo null | jq -r -S --arg pack "${PACK_VERSION}" '{ pack: $pack }' > ./builder/scripts/.util/tools.json
+
+    - name: Update implementation tools.json
+      env:
+        JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
+        PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+      run: |
+        echo null | jq -r -S --arg pack "${PACK_VERSION}" --arg jam "${JAM_VERSION}" '{ pack: $pack }' > ./implementation/scripts/.util/tools.json
+
+    - name: Update language-family tools.json
+      env:
+        JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
+        PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+      run: |
+        echo null | jq -r -S --arg pack "${PACK_VERSION}" --arg jam "${JAM_VERSION}" '{ pack: $pack }' > ./language-family/scripts/.util/tools.json
+
+    - name: Commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating tools"
+        pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/tools/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updates tools"
+        branch: automation/tools/update

--- a/actions/tools/latest/Dockerfile
+++ b/actions/tools/latest/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine/git
+
+RUN apk add \
+      bash \
+      curl \
+      jq \
+    && rm -rf /var/cache/apk/*
+
+COPY entrypoint /entrypoint
+
+ENTRYPOINT ["/entrypoint"]

--- a/actions/tools/latest/action.yml
+++ b/actions/tools/latest/action.yml
@@ -1,0 +1,25 @@
+name: 'Fetch Latest Tool Version'
+
+description: |
+  Fetches the latest version of a given tool
+
+inputs:
+  token:
+    description: 'Token used to authenticate user account'
+    required: true
+  repo:
+    description: 'Repo containing the tool to check for a latest version'
+    required: true
+
+outputs:
+  version:
+    description: The version of the latest release
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+  - --token
+  - ${{ inputs.token }}
+  - --repo
+  - ${{ inputs.repo }}

--- a/actions/tools/latest/entrypoint
+++ b/actions/tools/latest/entrypoint
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+function main() {
+  local token repo
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --token)
+        token="${2}"
+        shift 2
+        ;;
+
+      --repo)
+        repo="${2}"
+        shift 2
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\""
+        exit 1
+    esac
+  done
+
+  if [[ -z "${token}" ]]; then
+    echo "--token is a required flag"
+    exit 1
+  fi
+
+  if [[ -z "${repo}" ]]; then
+    echo "--repo is a required flag"
+    exit 1
+  fi
+
+  local version
+  version="$(
+    curl "https://api.github.com/repos/${repo}/releases/latest" \
+      --header "Authorization: token ${token}" \
+      --silent \
+      --location \
+    | jq -r -S .tag_name
+  )"
+
+  echo "::set-output name=version::${version}"
+}
+
+main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We have a `tools.json` that holds references to the latest versions of `pack` and `jam` that we use for each of the `builder`, `implementation`, and `language-family` scripts. This PR includes a new action for fetching the latest release of a tool, and then also a workflow to update the versions of `jam` and `pack` when they are released.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves #167
Resolves #190 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
