### PR TITLE
automatically push tags docs/v1.2.3 for each v1.2.3 release

### DIFF
--- a/language-family/.github/workflows/tag-docs-release.yml
+++ b/language-family/.github/workflows/tag-docs-release.yml
@@ -1,0 +1,38 @@
+name: Tag Documentation Release
+
+on:
+  release:
+    types:
+    - published
+  workflow_dispatch: {}
+
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Parse Event
+      id: event
+      run: |
+        echo "::set-output name=tag::$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get Release Tag
+      id: tag
+      uses: paketo-buildpacks/github-config/actions/tag/tag-docs-submodule@main
+      with:
+        version: ${{ steps.event.outputs.tag }}
+
+    - name: Create Docs Tag
+      run: |
+       git tag ${{ steps.tag.outputs.tag }}
+
+    - name: Push
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: main


### PR DESCRIPTION
In order to roll Hugo modules out to the other language family repos besides dotnet-core, we need to pull [this workflow](https://github.com/paketo-buildpacks/dotnet-core/blob/6a1330795ef13f26bfd5bdbc6c99d053b3944e7c/.github/workflows/tag-docs-release.yml) that automatically creates `docs/v1.2.3` tags on each buildpack release so that versions of docs modules are cut at the same time as buildpack versions.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
