### PR TITLE
Swaps .packit file references for .libbuildpack

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -67,7 +67,7 @@ function tools::install() {
   util::tools::jam::install \
     --directory "${BUILDPACKDIR}/.bin"
 
-  if [[ ! -f "${BUILDPACKDIR}/.packit" ]]; then
+  if [[ -f "${BUILDPACKDIR}/.libbuildpack" ]]; then
     util::tools::packager::install \
       --directory "${BUILDPACKDIR}/.bin"
   fi

--- a/implementation/scripts/package.sh
+++ b/implementation/scripts/package.sh
@@ -89,14 +89,7 @@ function buildpack::archive() {
 
   util::print::title "Packaging buildpack into ${BUILD_DIR}/buildpack.tgz..."
 
-  if [[ -f "${ROOT_DIR}/.packit" ]]; then
-    util::tools::jam::install --directory "${BIN_DIR}"
-
-    jam pack \
-      --buildpack "${ROOT_DIR}/buildpack.toml" \
-      --version "${version}" \
-      --output "${BUILD_DIR}/buildpack.tgz"
-  else
+  if [[ -f "${ROOT_DIR}/.libbuildpack" ]]; then
     util::tools::packager::install --directory "${BIN_DIR}"
 
     packager \
@@ -104,6 +97,13 @@ function buildpack::archive() {
       --archive \
       --version "${version}" \
       "${BUILD_DIR}/buildpack"
+  else
+    util::tools::jam::install --directory "${BIN_DIR}"
+
+    jam pack \
+      --buildpack "${ROOT_DIR}/buildpack.toml" \
+      --version "${version}" \
+      --output "${BUILD_DIR}/buildpack.tgz"
   fi
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Now that the majority of the buildpacks are using `packit` as their library, we can remove a bunch of extraneous files by swapping the conditional in the packaging script that determines which tool to use to package the buildpack. Once this is merged and propagates to all of the implementation repos, we can remove all of the `.packit` files from those repos. We can also remove the `.packit` file from the `bootstrapper`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
