### PR TITLE
Update workflow actions through this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,30 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/actions/dependency/parse/entrypoint"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/actions/dependency/update/entrypoint"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/actions/dispatch/entrypoint"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/actions/release/create/entrypoint"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/actions/release/reset-draft/entrypoint"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/actions/release/notes/language-family/entrypoint"
-    schedule:
-      interval: "daily"
+- package-ecosystem: gomod
+  directory: "/actions/dispatch/entrypoint"
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: "/actions/pull-request/download-artifact/entrypoint"
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: "/actions/release/create/entrypoint"
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: "/actions/release/reset-draft/entrypoint"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/builder"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/implementation"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/language-family"
+  schedule:
+    interval: daily

--- a/builder/.github/dependabot.yml
+++ b/builder/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily

--- a/implementation/.github/dependabot.yml
+++ b/implementation/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily

--- a/language-family/.github/dependabot.yml
+++ b/language-family/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The addition of `github-actions` to the dependabot configuration appears to be causing thrashing where dependabot bumps an action forward to a new version, and then the github-config update workflow bumps in back. This will continue in an endless loop.

This PR removes the dependabot configurations for `github-actions` in each repo type and will instead update them from this repo and propagate those updates via the github-config update workflow.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
