### PR TITLE
Allows PR base to be configured

### DIFF
--- a/actions/pull-request/open/action.yml
+++ b/actions/pull-request/open/action.yml
@@ -16,6 +16,9 @@ inputs:
   branch:
     description: 'Branch to PR'
     required: true
+  base:
+    description: 'Branch into which the code should be merged'
+    default: 'main'
 
 runs:
   using: 'docker'
@@ -29,3 +32,5 @@ runs:
   - ${{ inputs.body }}
   - "--branch"
   - ${{ inputs.branch }}
+  - "--base"
+  - ${{ inputs.base }}

--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 function main() {
-  local token title body branch
+  local token title body branch base
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
@@ -25,6 +25,11 @@ function main() {
 
       --branch)
         branch="${2}"
+        shift 2
+        ;;
+
+      --base)
+        base="${2}"
         shift 2
         ;;
 
@@ -54,7 +59,8 @@ function main() {
   pushd "${GITHUB_WORKSPACE}" > /dev/null || true
     gh pr create \
       --title "${title}" \
-      --body "${body}"
+      --body "${body}" \
+      --base "${base}"
   popd > /dev/null || true
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We'd like to be able to  submit PRs to branches other than the default. Including the `base` option allows this to be configured in a workflow, overriding the default value of `main`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
