### PR TITLE
correct tag pushing syntax

### DIFF
--- a/language-family/.github/workflows/tag-docs-release.yml
+++ b/language-family/.github/workflows/tag-docs-release.yml
@@ -31,8 +31,4 @@ jobs:
     - name: Create Docs Tag
       run: |
        git tag ${{ steps.tag.outputs.tag }}
-
-    - name: Push
-      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
-      with:
-        branch: main
+       git push origin ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, tag docs release workflows fail [like this](https://github.com/paketo-buildpacks/go/runs/2634100845?check_suite_focus=true) because the Push Branch action doesn't use the right syntax for pushing up a new tag. This PR corrects the workflow, as evidenced by [the workflow used in this passing run](https://github.com/paketo-buildpacks/dotnet-core/actions/runs/861826689/workflow)

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
