### PR TITLE
Push buildpackage: Check for version discrepancy

### DIFF
--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -25,6 +25,15 @@ jobs:
         output: "/github/workspace/buildpackage.cnb"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
+    - name: Validate version
+      run: |
+        buidpackTomlVersion=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r '.Labels."io.buildpacks.buildpackage.metadata" | fromjson | .version')
+        githubReleaseVersion="${{ steps.event.outputs.tag }}"
+        if [[ "$buidpackTomlVersion" != "$githubReleaseVersion" ]]; then
+          echo "Version in buildpack.toml ($buidpackTomlVersion) and github release ($githubReleaseVersion) are not identical"
+          exit 1
+        fi
+
     - name: Push to GCR
       env:
         GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}

--- a/language-family/.github/workflows/push-buildpackage.yml
+++ b/language-family/.github/workflows/push-buildpackage.yml
@@ -24,6 +24,15 @@ jobs:
         output: "/github/workspace/buildpackage.cnb"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
+    - name: Validate version
+      run: |
+        buidpackTomlVersion=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r '.Labels."io.buildpacks.buildpackage.metadata" | fromjson | .version')
+        githubReleaseVersion="${{ steps.event.outputs.tag }}"
+        if [[ "$buidpackTomlVersion" != "$githubReleaseVersion" ]]; then
+          echo "Version in buildpack.toml ($buidpackTomlVersion) and github release ($githubReleaseVersion) are not identical"
+          exit 1
+        fi
+
     - name: Push to GCR
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Maintainers may sometimes in error publish releases with
different versions on the release and in the buildpackage.
This validates the versions are same before pushing to
remote registries.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
