### PR TITLE
Lint workflows when they're changed in pull requests

### DIFF
--- a/.github/.yamllint
+++ b/.github/.yamllint
@@ -12,4 +12,3 @@ rules:
     check-multi-line-strings: false
   brackets:
     max-spaces-inside: -1
-

--- a/.github/.yamllint
+++ b/.github/.yamllint
@@ -1,0 +1,15 @@
+# Config for https://github.com/adrienverge/yamllint
+extends: default
+
+rules:
+  comments-indentation: disable
+  document-start: disable
+  truthy: disable
+  line-length: disable
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
+    check-multi-line-strings: false
+  brackets:
+    max-spaces-inside: -1
+

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,30 @@
+name: Lint YAML Changes
+
+on:
+  pull_request:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  lintYaml:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout github-config
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        path: github-config
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install yamllint
+      run: pip install yamllint
+
+    - name: Lint YAML files
+      run: yamllint . -c github-config/.github/.yamllint

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -3,8 +3,8 @@ name: Lint YAML Changes
 on:
   pull_request:
     paths:
-      - '**.yml'
-      - '**.yaml'
+    - '**.yml'
+    - '**.yaml'
 
 jobs:
   lintYaml:

--- a/builder/.github/workflows/approve-bot-pr.yml
+++ b/builder/.github/workflows/approve-bot-pr.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Test Pull Request"]
     types:
-      - completed
+    - completed
 
 jobs:
   download:
@@ -15,18 +15,18 @@ jobs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
     steps:
-      - name: 'Download artifact'
-        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
-        with:
-          name: "event-payload"
-          repo: ${{ github.repository }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workspace: "/github/workspace"
-          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-      - id: pr-data
-        run: |
-          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+    - name: 'Download artifact'
+      uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+      with:
+        name: "event-payload"
+        repo: ${{ github.repository }}
+        run_id: ${{ github.event.workflow_run.id }}
+        workspace: "/github/workspace"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - id: pr-data
+      run: |
+        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
 
   approve:
     name: Approve Bot PRs

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Get pack version
       id: pack-version
-      run : |
+      run: |
         version=$(jq -r .pack "scripts/.util/tools.json")
         echo "::set-output name=version::${version#v}"
 
@@ -52,7 +52,7 @@ jobs:
     - name: Checkout With History
       uses: actions/checkout/@v2
       with:
-        fetch-depth: 0 # gets full history
+        fetch-depth: 0  # gets full history
     - name: Compare With Previous Release
       id: compare_previous_release
       run: |

--- a/builder/.github/workflows/lint-yaml.yml
+++ b/builder/.github/workflows/lint-yaml.yml
@@ -1,0 +1,30 @@
+name: Lint YAML Changes
+
+on:
+  pull_request:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  lintYaml:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout github-config
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        path: github-config
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install yamllint
+      run: pip install yamllint
+
+    - name: Lint YAML files
+      run: yamllint . -c github-config/.github/.yamllint

--- a/builder/.github/workflows/lint-yaml.yml
+++ b/builder/.github/workflows/lint-yaml.yml
@@ -1,10 +1,10 @@
-name: Lint YAML Changes
+name: Lint Workflows
 
 on:
   pull_request:
     paths:
-    - '**.yml'
-    - '**.yaml'
+    - '.github/**.yml'
+    - '.github/**.yaml'
 
 jobs:
   lintYaml:
@@ -27,4 +27,4 @@ jobs:
       run: pip install yamllint
 
     - name: Lint YAML files
-      run: yamllint . -c github-config/.github/.yamllint
+      run: yamllint ./.github -c github-config/.github/.yamllint

--- a/builder/.github/workflows/lint-yaml.yml
+++ b/builder/.github/workflows/lint-yaml.yml
@@ -3,8 +3,8 @@ name: Lint YAML Changes
 on:
   pull_request:
     paths:
-      - '**.yml'
-      - '**.yaml'
+    - '**.yml'
+    - '**.yaml'
 
 jobs:
   lintYaml:

--- a/builder/.github/workflows/synchronize-labels.yml
+++ b/builder/.github/workflows/synchronize-labels.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: actions/checkout@v2
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/implementation/.github/workflows/approve-bot-pr.yml
+++ b/implementation/.github/workflows/approve-bot-pr.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Test Pull Request"]
     types:
-      - completed
+    - completed
 
 jobs:
   download:
@@ -15,18 +15,18 @@ jobs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
     steps:
-      - name: 'Download artifact'
-        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
-        with:
-          name: "event-payload"
-          repo: ${{ github.repository }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workspace: "/github/workspace"
-          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-      - id: pr-data
-        run: |
-          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+    - name: 'Download artifact'
+      uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+      with:
+        name: "event-payload"
+        repo: ${{ github.repository }}
+        run_id: ${{ github.event.workflow_run.id }}
+        workspace: "/github/workspace"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - id: pr-data
+      run: |
+        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
 
   approve:
     name: Approve Bot PRs

--- a/implementation/.github/workflows/codeql-analysis.yml
+++ b/implementation/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-  - cron: '0 0 * * *' # Once a day at midnight
+  - cron: '0 0 * * *'  # Once a day at midnight
 
 jobs:
   analyze:

--- a/implementation/.github/workflows/lint-yaml.yml
+++ b/implementation/.github/workflows/lint-yaml.yml
@@ -1,0 +1,30 @@
+name: Lint YAML Changes
+
+on:
+  pull_request:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  lintYaml:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout github-config
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        path: github-config
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install yamllint
+      run: pip install yamllint
+
+    - name: Lint YAML files
+      run: yamllint . -c github-config/.github/.yamllint

--- a/implementation/.github/workflows/lint-yaml.yml
+++ b/implementation/.github/workflows/lint-yaml.yml
@@ -1,10 +1,10 @@
-name: Lint YAML Changes
+name: Lint Workflows
 
 on:
   pull_request:
     paths:
-    - '**.yml'
-    - '**.yaml'
+    - '.github/**.yml'
+    - '.github/**.yaml'
 
 jobs:
   lintYaml:
@@ -27,4 +27,4 @@ jobs:
       run: pip install yamllint
 
     - name: Lint YAML files
-      run: yamllint . -c github-config/.github/.yamllint
+      run: yamllint ./.github -c github-config/.github/.yamllint

--- a/implementation/.github/workflows/lint-yaml.yml
+++ b/implementation/.github/workflows/lint-yaml.yml
@@ -3,8 +3,8 @@ name: Lint YAML Changes
 on:
   pull_request:
     paths:
-      - '**.yml'
-      - '**.yaml'
+    - '**.yml'
+    - '**.yaml'
 
 jobs:
   lintYaml:

--- a/implementation/.github/workflows/lint.yml
+++ b/implementation/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
-        with:
-          version: v1.32.2
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2.5.2
+      with:
+        version: v1.32.2

--- a/implementation/.github/workflows/synchronize-labels.yml
+++ b/implementation/.github/workflows/synchronize-labels.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: actions/checkout@v2
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/language-family/.github/workflows/approve-bot-pr.yml
+++ b/language-family/.github/workflows/approve-bot-pr.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Test Pull Request"]
     types:
-      - completed
+    - completed
 
 jobs:
   download:
@@ -15,18 +15,18 @@ jobs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
     steps:
-      - name: 'Download artifact'
-        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
-        with:
-          name: "event-payload"
-          repo: ${{ github.repository }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workspace: "/github/workspace"
-          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-      - id: pr-data
-        run: |
-          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+    - name: 'Download artifact'
+      uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+      with:
+        name: "event-payload"
+        repo: ${{ github.repository }}
+        run_id: ${{ github.event.workflow_run.id }}
+        workspace: "/github/workspace"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - id: pr-data
+      run: |
+        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
 
   approve:
     name: Approve Bot PRs

--- a/language-family/.github/workflows/lint-yaml.yml
+++ b/language-family/.github/workflows/lint-yaml.yml
@@ -1,0 +1,30 @@
+name: Lint YAML Changes
+
+on:
+  pull_request:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  lintYaml:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout github-config
+      uses: actions/checkout@v2
+      with:
+        repository: paketo-buildpacks/github-config
+        path: github-config
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install yamllint
+      run: pip install yamllint
+
+    - name: Lint YAML files
+      run: yamllint . -c github-config/.github/.yamllint

--- a/language-family/.github/workflows/lint-yaml.yml
+++ b/language-family/.github/workflows/lint-yaml.yml
@@ -1,10 +1,10 @@
-name: Lint YAML Changes
+name: Lint Workflows
 
 on:
   pull_request:
     paths:
-    - '**.yml'
-    - '**.yaml'
+    - '.github/**.yml'
+    - '.github/**.yaml'
 
 jobs:
   lintYaml:
@@ -27,4 +27,4 @@ jobs:
       run: pip install yamllint
 
     - name: Lint YAML files
-      run: yamllint . -c github-config/.github/.yamllint
+      run: yamllint ./.github -c github-config/.github/.yamllint

--- a/language-family/.github/workflows/lint-yaml.yml
+++ b/language-family/.github/workflows/lint-yaml.yml
@@ -3,8 +3,8 @@ name: Lint YAML Changes
 on:
   pull_request:
     paths:
-      - '**.yml'
-      - '**.yaml'
+    - '**.yml'
+    - '**.yaml'
 
 jobs:
   lintYaml:

--- a/language-family/.github/workflows/lint.yml
+++ b/language-family/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
-        with:
-          version: v1.32.2
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2.5.2
+      with:
+        version: v1.32.2

--- a/language-family/.github/workflows/synchronize-labels.yml
+++ b/language-family/.github/workflows/synchronize-labels.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: actions/checkout@v2
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
It really grinds my gears when I write or update a Github action and my hopes are dashed by YAML errors that I didn't catch.

This PR adds workflows that lint all the yaml files in a the `.github` directory using a common config that's checked into this repo at `.github/.yamllint`

Here's the linter: https://github.com/adrienverge/yamllint
and here's the docs about how configuration works: https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration

I set up the config such that our existing workflows would require minimal changes to pass the linter. We can make these stricter as we see fit.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
