### PR TITLE
Adds `jam` to builder smoke tests for buildpackless builders

### DIFF
--- a/builder/scripts/smoke.sh
+++ b/builder/scripts/smoke.sh
@@ -67,6 +67,9 @@ USAGE
 function tools::install() {
   util::tools::pack::install \
     --directory "${BUILDERDIR}/.bin"
+
+  util::tools::jam::install \
+    --directory "${BUILDPACKDIR}/.bin"
 }
 
 function builder::create() {


### PR DESCRIPTION
The buildpackless builders use `jam` in their smoke tests to build a buildpack to run an app against. Therefore `jam` installation needs to be added to the smoke test script so that it will work for all builders.