### PR TITLE
actions/releases: New jam only works with certain buildpacks

### DIFF
--- a/actions/release/notes/Dockerfile
+++ b/actions/release/notes/Dockerfile
@@ -10,10 +10,10 @@ RUN apk add \
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-ARG jam_version=v1.0.0
+ARG jam_version=v0.9.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
-      && curl "https://github.com/paketo-buildpacks/jam/releases/download/${jam_version}/jam-linux" \
+      && curl "https://github.com/paketo-buildpacks/packit/releases/download/${jam_version}/jam-linux" \
         --silent \
         --location \
         --output "/bin/jam" \


### PR DESCRIPTION
jam summarize fails if metadata not in the same format as expected
by the tool

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
