### PR TITLE
Make buildpackless base builder default for tests

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -82,7 +82,7 @@ function images::pull() {
   fi
 
   if [[ "${builder}" == "null" || -z "${builder}" ]]; then
-    builder="index.docker.io/paketobuildpacks/builder:base"
+    builder="index.docker.io/paketobuildpacks/builder:buildpackless-base"
   fi
 
   util::print::title "Pulling builder image..."

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -67,7 +67,7 @@ function images::pull() {
   fi
 
   if [[ "${builder}" == "null" || -z "${builder}" ]]; then
-    builder="index.docker.io/paketobuildpacks/builder:base"
+    builder="index.docker.io/paketobuildpacks/builder:buildpackless-base"
   fi
 
   util::print::title "Pulling builder image..."


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
paketobuildpacks/builder:buildpackless-base is live! Let's use it to speed up tests.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
