### PR TITLE
require status check: Semver PR labels

### DIFF
--- a/scripts/repo_rules.sh
+++ b/scripts/repo_rules.sh
@@ -136,6 +136,10 @@ function rules() {
     valid=1
   fi
 
+  if ! rules::checks::labels "$(jq '.required_status_checks.contexts | index("Ensure Minimal Semver Labels")' <<< "${json}")"; then
+    valid=1
+  fi
+
   if ! rules::history::linear "$(jq .required_linear_history.enabled <<< "${json}")"; then
     valid=1
   fi
@@ -213,6 +217,16 @@ function rules::checks::integration() {
 
   if [[ -z "${status_checks_int}" || "${status_checks_int}" == "null" ]]; then
     util::print::yellow 'Merging: Required status checks do not contain Integration Tests'
+    return 1
+  fi
+}
+
+function rules::checks::labels() {
+  local status_checks_labels
+  status_checks_labels="${1}"
+
+  if [[ -z "${status_checks_labels}" || "${status_checks_labels}" == "null" ]]; then
+    util::print::yellow 'Merging: Required status checks do not contain "Ensure Minimal Semver Labels"'
     return 1
   fi
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds one more require status check to the set we apply to all buildpacks. This one requires that the Ensure Minimal Semver Labels status check is required. This is needed so we can ultimately use PRs' labels to determine buildpack release versions. The script will be useful for maintainers to quickly see which repos need to have the required check added.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
