### PR TITLE
check PR labels as soon as PR is opened

### DIFF
--- a/implementation/.github/workflows/check-pr-labels.yml
+++ b/implementation/.github/workflows/check-pr-labels.yml
@@ -5,6 +5,7 @@ on:
     - main
     types:
     - synchronize
+    - opened
     - reopened
     - labeled
     - unlabeled

--- a/language-family/.github/workflows/check-pr-labels.yml
+++ b/language-family/.github/workflows/check-pr-labels.yml
@@ -5,6 +5,7 @@ on:
     - main
     types:
     - synchronize
+    - opened
     - reopened
     - labeled
     - unlabeled


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Ideally, we want the Ensure Minimal Semver Labels status check to be required for all buildpack PRs. It must trigger when PRs open so that it always runs (and fails appropriately). Else, PRs that only have one commit (i.e. are never `synchronized`) will never trigger the check and it will hang in a "Expected" state.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
