### PR TITLE
PR autolabeling should "fail green" when no auth is provided

### DIFF
--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -32,6 +32,16 @@ function main() {
     esac
   done
 
+  set +e
+  gh auth status
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "No Github credentials provided. Skipping labeling."
+    echo "::set-output name=label::"
+    exit 0
+  fi
+  set -e
+
   while read -r changed; do
     echo "File changed: ${changed}"
     # scan through an allow list. does each element of the changed files match something in the allow list?


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves #365 
When dependabot opens PRs, these are technically from "forks". Workflows run against these PRs don't have access to repo secrets. It'd be nice if the auto-label action doesn't fail with a big red X just because auth wasn't provided.

The action already "fails green" when the no label can be determined.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
