### PR TITLE
Check autolabeler failure modes

### DIFF
--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -42,6 +42,14 @@ function main() {
   fi
   set -e
 
+  # Check that the files-changed API endpoint is valid for the given parameters
+  gh api /repos/"${repo}"/pulls/"${number}"/files --jq '.[].filename' > /dev/null
+
+  if ! [ -f "${patchfiles}" ]; then
+    echo "${patchfiles} does not exist."
+    exit 1
+  fi
+
   while read -r changed; do
     echo "File changed: ${changed}"
     # scan through an allow list. does each element of the changed files match something in the allow list?


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
I uncovered some edge cases where the autolabeler "fails green" when it probably shouldn't:
- when the allowlist file doesn't exist
- when the attempt to fetch the PR changed files fails

I added explicit failure cases for these.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
