### PR TITLE
Actions/buildpack/update: make configurable

### DIFF
--- a/actions/buildpack/update/action.yml
+++ b/actions/buildpack/update/action.yml
@@ -3,6 +3,14 @@ name: 'Update buildpack.toml with new buildpack versions'
 description: |
   This action updates the buildpack.toml with any new buildpack versions.
 
+inputs:
+  buildpack_toml_path:
+    description: 'Relative path to buildpack.toml'
+    default: 'buildpack.toml'
+  package_toml_path:
+    description: 'Relative path to package.toml'
+    default: 'package.toml'
+
 runs:
   using: 'composite'
   steps:
@@ -36,5 +44,5 @@ runs:
       #!/usr/bin/env bash
       set -eu
       jam update-buildpack \
-        --buildpack-file "${PWD}/buildpack.toml" \
-        --package-file "${PWD}/package.toml"
+        --buildpack-file "${PWD}/${{ inputs.buildpack_toml_path }}" \
+        --package-file "${PWD}/${{ inputs.package_toml_path }}"


### PR DESCRIPTION
This pull request makes the path to the buildpack.toml/package.toml configurable.

A buildpack's descriptor must be named `buildpack.toml` but the source code repo may maintain
this descriptor file under different names. An example is when when the same repository is used to
generate different flavor of a buildpack with the same funtion. Such a buildpack source code repo may have
`buildpack-x.toml` and `buildpack-y.toml` to generated `id-x` and `id-y` buildpack respectively.

#### Testing changes

Tested out https://github.com/arjun024/python/blob/automation/buildpack.toml/update/.github/workflows/update-buildpack-toml.yml#L22-L26 with and without defaults.

See 
https://github.com/arjun024/python/commit/c9e97c4b0354e6d33c0f40581a6ebd30934335ab
and
https://github.com/arjun024/python/commit/4306f1d06283e100298bd0cc063fc9d2339ebe52


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
