### PR TITLE
add ability to install libpak create-package

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -33,32 +33,45 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         repo: buildpacks/pack
 
+    - name: Fetch Latest create-package
+      id: latest-create-package
+      uses: paketo-buildpacks/github-config/actions/tools/latest@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        repo: paketo-buildpacks/libpak
+
     - name: Update builder tools.json
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
       run: |
         echo null | jq -r -S --arg pack "${PACK_VERSION}" \
                              --arg jam "${JAM_VERSION}" \
-                             '{ pack: $pack, jam: $jam }' > ./builder/scripts/.util/tools.json
+                             --arg createpackage "${CREATE_PACKAGE_VERSION}" \
+                             '{ pack: $pack, jam: $jam, createpackage: $createpackage }' > ./builder/scripts/.util/tools.json
 
     - name: Update implementation tools.json
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
       run: |
         echo null | jq -r -S --arg pack "${PACK_VERSION}" \
                              --arg jam "${JAM_VERSION}" \
-                             '{ pack: $pack, jam: $jam }' > ./implementation/scripts/.util/tools.json
+                             --arg createpackage "${CREATE_PACKAGE_VERSION}" \
+                             '{ pack: $pack, jam: $jam, createpackage: $createpackage }' > ./implementation/scripts/.util/tools.json
 
     - name: Update language-family tools.json
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
       run: |
         echo null | jq -r -S --arg pack "${PACK_VERSION}" \
                              --arg jam "${JAM_VERSION}" \
-                             '{ pack: $pack, jam: $jam }' > ./language-family/scripts/.util/tools.json
+                             --arg createpackage "${CREATE_PACKAGE_VERSION}" \
+                             '{ pack: $pack, jam: $jam, createpackage: $createpackage }' > ./language-family/scripts/.util/tools.json
 
     - name: Commit
       id: commit

--- a/implementation/scripts/.util/tools.json
+++ b/implementation/scripts/.util/tools.json
@@ -1,4 +1,5 @@
 {
   "jam": "v1.1.1",
-  "pack": "v0.22.0"
+  "pack": "v0.22.0",
+  "createpackage": "v1.55.1"
 }

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -133,6 +133,33 @@ function util::tools::packager::install () {
     fi
 }
 
+function util::tools::create-package::install () {
+  local dir version
+    while [[ "${#}" != 0 ]]; do
+      case "${1}" in
+        --directory)
+          dir="${2}"
+          shift 2
+          ;;
+
+        *)
+          util::print::error "unknown argument \"${1}\""
+          ;;
+
+      esac
+    done
+
+    version="$(jq -r .createpackage "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
+
+    mkdir -p "${dir}"
+    util::tools::path::export "${dir}"
+
+    if [[ ! -f "${dir}/create-package" ]]; then
+      util::print::title "Installing create-package"
+      GOBIN="${dir}" go install -ldflags="-s -w" "github.com/paketo-buildpacks/libpak/cmd/create-package@${version}"
+    fi
+}
+
 function util::tools::tests::checkfocus() {
   testout="${1}"
   if grep -q 'Focused: [1-9]' "${testout}"; then

--- a/language-family/scripts/.util/tools.json
+++ b/language-family/scripts/.util/tools.json
@@ -1,4 +1,5 @@
 {
   "jam": "v1.1.1",
-  "pack": "v0.22.0"
+  "pack": "v0.22.0",
+  "createpackage": "v1.55.1"
 }

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -119,6 +119,8 @@ function util::tools::packager::install () {
 
         *)
           util::print::error "unknown argument \"${1}\""
+          ;;
+
       esac
     done
 
@@ -126,8 +128,35 @@ function util::tools::packager::install () {
     util::tools::path::export "${dir}"
 
     if [[ ! -f "${dir}/packager" ]]; then
-        util::print::title "Installing packager"
-        GOBIN="${dir}" go get github.com/cloudfoundry/libcfbuildpack/packager
+      util::print::title "Installing packager"
+      GOBIN="${dir}" go get -u github.com/cloudfoundry/libcfbuildpack/packager
+    fi
+}
+
+function util::tools::create-package::install () {
+  local dir version
+    while [[ "${#}" != 0 ]]; do
+      case "${1}" in
+        --directory)
+          dir="${2}"
+          shift 2
+          ;;
+
+        *)
+          util::print::error "unknown argument \"${1}\""
+          ;;
+
+      esac
+    done
+
+    version="$(jq -r .createpackage "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
+
+    mkdir -p "${dir}"
+    util::tools::path::export "${dir}"
+
+    if [[ ! -f "${dir}/create-package" ]]; then
+      util::print::title "Installing create-package"
+      GOBIN="${dir}" go install -ldflags="-s -w" "github.com/paketo-buildpacks/libpak/cmd/create-package@${version}"
     fi
 }
 


### PR DESCRIPTION
alternative to jam pack for packaging buildpacks; needed to build syft buildpack with offline dependencies

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds the ability to package buildpacks that use `create-package` instead of `jam pack` for packaging. This is important for properly packaging libpak buildpacks with offline dependencies.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
