### PR TITLE
Check that label can be applied before removing it

### DIFF
--- a/actions/pull-request/auto-semver-label/action.yml
+++ b/actions/pull-request/auto-semver-label/action.yml
@@ -24,14 +24,6 @@ runs:
         exit 0
       fi
         echo "::set-output name=status::true"
-  - name: Clear Semver Label
-    shell: bash
-    run: |
-      if [[ "${{ steps.auth.outputs.status }}" == "true" ]]; then
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:patch"
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:minor"
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:major"
-      fi
   - name: Check Files Changed
     id: changes
     shell: bash
@@ -40,6 +32,14 @@ runs:
         ${{ github.action_path }}/check-files-changed.sh --repo "${{ github.repository }}" \
         --number "${{ github.event.number }}" \
         --patchfiles "${GITHUB_WORKSPACE}/.github/.patch_files"
+      fi
+  - name: Clear Semver Label
+    shell: bash
+    run: |
+      if [[ "${{ steps.auth.outputs.status }}" == "true" ]]; then
+        gh pr edit "${{ github.event.number }}" --remove-label "semver:patch"
+        gh pr edit "${{ github.event.number }}" --remove-label "semver:minor"
+        gh pr edit "${{ github.event.number }}" --remove-label "semver:major"
       fi
   - name: Add Semver Label
     shell: bash


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This action would prematurely remove the semver label from a PR before it figured out if it was able to add one automatically. This change just swaps these steps to do the check before removing and ultimately replacing the label. This should save us from having to reapply a label that gets accidentally removed by this action when it cannot apply the label itself.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
