### PR TITLE
Only clear labels if autolabeler returns a result

### DIFF
--- a/actions/pull-request/auto-semver-label/action.yml
+++ b/actions/pull-request/auto-semver-label/action.yml
@@ -37,9 +37,11 @@ runs:
     shell: bash
     run: |
       if [[ "${{ steps.auth.outputs.status }}" == "true" ]]; then
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:patch"
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:minor"
-        gh pr edit "${{ github.event.number }}" --remove-label "semver:major"
+        if [ -n "${{ steps.changes.outputs.label }}" ]; then
+          gh pr edit "${{ github.event.number }}" --remove-label "semver:patch"
+          gh pr edit "${{ github.event.number }}" --remove-label "semver:minor"
+          gh pr edit "${{ github.event.number }}" --remove-label "semver:major"
+        fi
       fi
   - name: Add Semver Label
     shell: bash


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
So the autolabeler won't clear human-added labels if the PR can't be auto-labeled.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
