### PR TITLE
Autolabel dependabot PRs as patch changes

### DIFF
--- a/actions/pull-request/auto-semver-label/action.yml
+++ b/actions/pull-request/auto-semver-label/action.yml
@@ -24,13 +24,14 @@ runs:
         exit 0
       fi
         echo "::set-output name=status::true"
-  - name: Check Files Changed
+  - name: Check For Auto-labelable Changes
     id: changes
     shell: bash
     run: |
       if [[ "${{ steps.auth.outputs.status }}" == "true" ]]; then
         ${{ github.action_path }}/check-files-changed.sh --repo "${{ github.repository }}" \
         --number "${{ github.event.number }}" \
+        --author "${{ github.event.pull_request.user.login }}" \
         --patchfiles "${GITHUB_WORKSPACE}/.github/.patch_files"
       fi
   - name: Clear Semver Label

--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -3,7 +3,7 @@ set -eu
 set -o pipefail
 
 function main() {
-  local repo number patchfiles
+  local repo number author patchfiles
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
@@ -14,6 +14,11 @@ function main() {
 
       --number)
         number="${2}"
+        shift 2
+        ;;
+
+      --author)
+        author="${2}"
         shift 2
         ;;
 
@@ -31,6 +36,12 @@ function main() {
         exit 1
     esac
   done
+
+  if [[ "${author}" == "dependabot[bot]" ]]; then
+    echo "PR author is dependabot. Labeling as patch."
+    echo "::set-output name=label::patch"
+    exit 0
+  fi
 
   set +e
   gh auth status
@@ -52,7 +63,8 @@ function main() {
 
   while read -r changed; do
     echo "File changed: ${changed}"
-    # scan through an allow list. does each element of the changed files match something in the allow list?
+    # scan through an allow list. does each element of the changed files match
+    # something in the allow list?
     safe=0
     while read -r file; do
       if [[ "${changed}" =~ ${file} ]]; then


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When dependabot PRs go out to our repos, they require a lot of maintainer intervention since they aren't auto-labeled. 

The simplest mitigation I can think of is to automatically label dependabot PRs as patch changes. My reasoning is that dependency bumps that *shouldn't* be labeled as patch changes to the buildpack will cause test failures. The main dependency bump that I slightly worry about autolabeling as patch is packit. But:
- we usually mark unused structs, fields, functions as deprecated, which will cause linter failures
- otherwise, we add typically features that buildpack authors need to take action to use; simply bumping packit doesn't generally add buildpack features.

So I might be convinced that it's fine to label all dependency bumps as patches. Let's hash this question out here.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
