### PR TITLE
Force label check to hit Github API

### DIFF
--- a/implementation/.github/workflows/label-pr.yml
+++ b/implementation/.github/workflows/label-pr.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: mheap/github-action-required-labels@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         count: 1
         labels: semver:major, semver:minor, semver:patch

--- a/language-family/.github/workflows/label-pr.yml
+++ b/language-family/.github/workflows/label-pr.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: mheap/github-action-required-labels@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         count: 1
         labels: semver:major, semver:minor, semver:patch


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The attempt to consolidate the PR label actions in #438 didn't quite work as intended, as evidenced [here](https://github.com/paketo-buildpacks/go-dist/actions/runs/1993426547). From the docs of the [github action that checks for labels](https://github.com/mheap/github-action-required-labels):
> By default this actions reads `event.json`, which will not detect when a label is added in an earlier step. To force an API call, set the `GITHUB_TOKEN` environment variable

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
