### PR TITLE
Use same release automation for all builders

### DIFF
--- a/builder/.github/release-drafter-config.yml
+++ b/builder/.github/release-drafter-config.yml
@@ -1,0 +1,25 @@
+# Config for https://github.com/release-drafter/release-drafter
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
+commitish: main
+
+change-template: '- $TITLE [#$NUMBER] by [@$AUTHOR](https://github.com/$AUTHOR)'
+template: |
+  ## Full Changelog
+
+  Following pull requests got merged for this release:
+
+  $CHANGES
+
+version-resolver:
+  major:
+    labels:
+      - 'semver:major'
+  minor:
+    labels:
+      - 'semver:minor'
+  patch:
+    labels:
+      - 'semver:patch'
+  default: patch

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -35,13 +35,17 @@ jobs:
 
     - name: Run Smoke Tests
       run: ./scripts/smoke.sh --name builder
+
     - name: Generate Release Notes
       id: notes
       run: |
-        notes="$(pack inspect-builder builder | grep -v 'Inspecting builder' | grep -v 'REMOTE:' | grep -v 'LOCAL:' | grep -v '\(not present\)' | sed -e '/./,$!d')"
-        notes="${notes//'%'/'%25'}"
-        notes="${notes//$'\n'/'%0A'}"
-        notes="${notes//$'\r'/'%0D'}"
+        notes="$(pack inspect-builder builder | grep -v 'Inspecting builder' \
+          | grep -v 'REMOTE:' \
+          | grep -v 'LOCAL:' \
+          | grep -v '\(not present\)' \
+          | grep -v 'Warning' \
+          | sed -e '/./,$!d' \
+          | awk -F, '{printf "%s\\n", $0}')"
         echo "::set-output name=body::${notes}"
 
   release:
@@ -53,6 +57,7 @@ jobs:
       uses: actions/checkout/@v2
       with:
         fetch-depth: 0  # gets full history
+
     - name: Compare With Previous Release
       id: compare_previous_release
       run: |
@@ -62,21 +67,30 @@ jobs:
         else
           echo "::set-output name=builder_changes::true"
         fi
-    - name: Tag
-      id: tag
+
+    - name: Publish Release
+      id: publish
       if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
-      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
-    - name: Create Release
-      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
-      uses: paketo-buildpacks/github-config/actions/release/create@main
+      uses: release-drafter/release-drafter@v5
       with:
-        repo: ${{ github.repository }}
-        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-        tag_name: v${{ steps.tag.outputs.tag }}
-        target_commitish: ${{ github.sha }}
-        name: v${{ steps.tag.outputs.tag }}
-        body: |
-          ```
-          ${{ needs.smoke.outputs.release_notes }}
-          ```
-        draft: false
+        config-name: release-drafter-config.yml
+        publish: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Update Release Notes
+      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
+      run: |
+        set -e
+        payload="{\"body\" : \"\`\`\`\n${RELEASE_BODY}\n\`\`\`\"}"
+
+        curl --fail \
+          -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+          -d "${payload}"
+      env:
+        RELEASE_ID: ${{ steps.publish.outputs.id }}
+        RELEASE_BODY: ${{ needs.smoke.outputs.release_notes }}
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, the Paketo Full Builder uses different release automation from the other builders. This is confusing to reason about. This PR sets up all the builders to use the same release automation that's [in the Full Builder repo](https://github.com/paketo-buildpacks/full-builder/blob/main/.github/workflows/create-release.yml). I use the release-drafter action instead of Paketo's bespoke semver versioning because the release-drafter supports assigning a "default" version to a release if PRs don't have labels. It's worked like a charm on the Full Builder repo for a while now.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
