### PR TITLE
Run  'go install' for installing libcfbuildpack/packager

### DIFF
--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -129,7 +129,7 @@ function util::tools::packager::install () {
 
     if [[ ! -f "${dir}/packager" ]]; then
       util::print::title "Installing packager"
-      GOBIN="${dir}" go get -u github.com/cloudfoundry/libcfbuildpack/packager
+      GOBIN="${dir}" go install github.com/cloudfoundry/libcfbuildpack/packager
     fi
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The bump to Go 1.18 in our workflows made the installation of `libcfbuildpack/packager` stop working for PHP buildpacks because Go moved from using `go get...` to `go install` for installing packages. (Ex. https://github.com/paketo-buildpacks/php-composer/pull/294) This change makes sure `packager` can be installed successfully when running the PHP Web and PHP Composer integration tests.

We will remove the entire `packager` section from tools-related scripts when the PHP rewrite is complete.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
