### PR TITLE
Use pull_request_target trigger in auto-label workflow

### DIFF
--- a/implementation/.github/workflows/label-pr.yml
+++ b/implementation/.github/workflows/label-pr.yml
@@ -1,6 +1,6 @@
 name: Set / Validate PR Labels
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - main
     types:

--- a/language-family/.github/workflows/label-pr.yml
+++ b/language-family/.github/workflows/label-pr.yml
@@ -1,6 +1,6 @@
 name: Set / Validate PR Labels
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - main
     types:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Should fix recurring issues we've seen with the Semver Labeling workflow in which the auto-labeling step fails because it cannot access the repository secrets. Screenshot of the issue of empty `GITHUB_TOKEN` is attached:
![Screen Shot 2022-04-13 at 12 17 24 PM](https://user-images.githubusercontent.com/20341599/163274316-e0cbca0d-e50e-4191-9b3b-28c64fb98e6f.png)


This PR uses the `pull_request_target` trigger instead of `pull_request` which gives the workflow access to repository secrets. 

**Important note** 
The "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)" blog post mentions that `you should make sure that you do not check out, build, or run untrusted code from the pull request with this event`. 

The [auto-label semver action](https://github.com/paketo-buildpacks/github-config/blob/main/actions/pull-request/auto-semver-label/action.yml) that gets used in the workflow does perform a [`checkout` of the main branch](https://github.com/paketo-buildpacks/github-config/blob/e060245b367352729402e438dcc6ccd13e910b7b/actions/pull-request/auto-semver-label/action.yml#L10-L13). The danger of a `checkout` with secret access lies in checking out a malicious PR branch, so I don't believe this action to be risky.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
