### PR TITLE
increment-tag: mark as safe dir & make action exit 1 on err

### DIFF
--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -3,6 +3,9 @@
 # requires run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 # before executing this script
 
+set -eu
+set -o pipefail
+
 main() {
   local current_version
 
@@ -24,6 +27,7 @@ main() {
     esac
   done
 
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}"
   if git describe --exact-match --tags HEAD > /dev/null 2>&1; then
     echo "error: HEAD has already been tagged"
     exit 1


### PR DESCRIPTION
* Currently when the optional `current_version` is not provided, the git command errors with
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
* Also when this failure happens, action still exits 0 - so set opt to error on failure
