### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/implementation/.github/workflows/lint.yml
+++ b/implementation/.github/workflows/lint.yml
@@ -25,3 +25,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
+        args: --timeout 3m0s

--- a/language-family/.github/workflows/lint.yml
+++ b/language-family/.github/workflows/lint.yml
@@ -25,3 +25,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
+        args: --timeout 3m0s


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As various other golangci-lint GHA users [have noticed](https://github.com/golangci/golangci-lint-action/issues/297), sometimes the action runs slower than would be expected on your local machine, resulting in timeouts. This increases the timeout from the default (1 minute) to reduce maintainers' toil rerunning the linter.

Some examples of linter runs that timed out:
- https://github.com/paketo-buildpacks/go-build/actions/runs/2375799354/attempts/1
- https://github.com/paketo-community/go-generate/actions/runs/2378009981/attempts/1

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
