### PR TITLE
Bump to `github/codeql-action/*@v2`

### DIFF
--- a/implementation/.github/workflows/codeql-analysis.yml
+++ b/implementation/.github/workflows/codeql-analysis.yml
@@ -24,12 +24,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
`github/codeql-action/*@v1` is being deprecated, so let's proactively bump to `@v2`.

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/