### PR TITLE
Fix typo in package outputs

### DIFF
--- a/actions/stack/diff-package-receipts/entrypoint/main.go
+++ b/actions/stack/diff-package-receipts/entrypoint/main.go
@@ -85,8 +85,8 @@ func main() {
 			modified = append(modified, ModifiedCycloneDXComponent{
 				Name:            curPackage.Name,
 				PreviousVersion: prevPackage.Version,
-				CurrentVersion:  prevPackage.Version,
 				PreviousPURL:    prevPackage.PURL,
+				CurrentVersion:  curPackage.Version,
 				CurrentPURL:     curPackage.PURL,
 			})
 		}


### PR DESCRIPTION
This was resulting in confusing release notes where packages were updated to the "same version"

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This typo was causing head-scratching release notes like the ones for jammy tiny stack [v0.0.5](https://github.com/paketo-buildpacks/jammy-tiny-stack/releases/tag/v0.0.5) where "modified" packages appeared to have unchanged versions.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
