### PR TITLE
Push bionic stacks to legacy locations

### DIFF
--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -54,6 +54,21 @@ jobs:
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${registry_repo}:${{ steps.event.outputs.tag }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${registry_repo}:latest"
 
+        # If the repository name contains 'bionic', let's push it to legacy image locations as well:
+        #    paketobuildpacks/{build/run}:{version}-{variant}
+        #    paketobuildpacks/{build/run}:{version}-{variant}-cnb
+        if [[ ${registry_repo} == "bionic"-* ]];
+          # Strip the final part from a repo name after the `-`
+          # bionic-tiny --> tiny
+          variant=$(echo ${registry_repo} | sed 's/^[^-]*-//')
+
+          sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build:${{ steps.event.outputs.tag }}-${variant}"
+          sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build:${{ steps.event.outputs.tag }}-${variant}-cnb"
+          sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${{ steps.event.outputs.tag }}-${variant}"
+          sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${{ steps.event.outputs.tag }}-${variant}-cnb"
+        fi
+
+
   failure:
     name: Alert on Failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

As a part of https://github.com/paketo-buildpacks/rfcs/issues/197, Bionic stacks will need to be pushed to legacy locations in addition to the new locations outlined in the RFC. This PR adds logic to do that for the `bionic-<tiny/base/full>-stack` repos.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
