### PR TITLE
Test builders on demand

### DIFF
--- a/builder/.github/labels.yml
+++ b/builder/.github/labels.yml
@@ -28,3 +28,9 @@
 - name: good first issue
   description: A good first issue to get started with
   color: d3fc03
+- name: "failure:release"
+  description: An issue filed automatically when a release workflow run fails
+  color: f00a0a
+- name: "failure:push"
+  description: An issue filed automatically when a push buildpackage workflow run fails
+  color: f00a0a

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -94,3 +94,22 @@ jobs:
         RELEASE_ID: ${{ steps.publish.outputs.id }}
         RELEASE_BODY: ${{ needs.smoke.outputs.release_notes }}
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-latest
+    needs: [ smoke, release ]
+    if: ${{ always() && needs.smoke.result == 'failure' ||  needs.release.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:release"
+        comment_if_exists: true
+        issue_title: "Failure: Create Release workflow"
+        issue_body: |
+          Create Release workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/test-builder.yml
+++ b/builder/.github/workflows/test-builder.yml
@@ -1,0 +1,21 @@
+name: Test Builder
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+
+  smoke:
+    name: Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run Smoke Tests
+      run: ./scripts/smoke.sh


### PR DESCRIPTION
to sniff out out-of-band changes that have caused
the builder to break. e.g. a dependency shipped by a buildpack
suddenly breaks.

also, adds some failure notifications

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
