### PR TITLE
Fix unbound builders variable

### DIFF
--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -59,8 +59,8 @@ function tools::install() {
 }
 
 function images::pull() {
-  local builder
-  builder=""
+  local builders
+  builders=""
 
   if [[ -f "${BUILDPACKDIR}/integration.json" ]]; then
     builders="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"


### PR DESCRIPTION
Language family `integration.sh` could have an unbound variable `builders` when `integration.json` is not present.

Example: https://github.com/paketo-buildpacks/python/runs/7314119664