### PR TITLE
Gather PR integration test results in one job

### DIFF
--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -18,6 +18,8 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    outputs:
+      builders: ${{ steps.builders.outputs.builders }}
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -27,11 +29,22 @@ jobs:
       uses: actions/checkout@v3
     - name: Run Unit Tests
       run: ./scripts/unit.sh
+    - name: Get builders from integration.json
+      id: builders
+      run: |
+        source "${{ github.workspace }}/scripts/.util/builders.sh"
+        builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
+        printf "Output: %s\n" "${builders}"
+        printf "::set-output name=builders::%s\n" "${builders}"
 
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: unit
+    strategy:
+      matrix:
+        builder: ${{ fromJSON(needs.unit.outputs.builders) }}
+      fail-fast: false  # don't cancel all test jobs when one fails
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -41,7 +54,7 @@ jobs:
       uses: actions/checkout@v3
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
     - name: Run Integration Tests
-      run: ./scripts/integration.sh --use-token
+      run: ./scripts/integration.sh --use-token --builder ${{ matrix.builder }}
       env:
         GIT_TOKEN: ${{ github.token }}
 

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         printf "::set-output name=builders::%s\n" "${builders}"
 
   integration:
-    name: Integration Tests
+    name: Integration Tests with Builders
     runs-on: ubuntu-latest
     needs: unit
     strategy:
@@ -60,6 +60,15 @@ jobs:
       run: ./scripts/integration.sh --use-token --builder ${{ matrix.builder }}
       env:
         GIT_TOKEN: ${{ github.token }}
+
+  roundup:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+    - run: |
+        echo "Integration tests passed against all builders"
+        exit 0
 
   upload:
     name: Upload Workflow Event Payload

--- a/language-family/.github/workflows/create-draft-release.yml
+++ b/language-family/.github/workflows/create-draft-release.yml
@@ -15,9 +15,30 @@ on:
 concurrency: release
 
 jobs:
+  builders:
+    name: Get Builders for Testing
+    runs-on: ubuntu-latest
+    outputs:
+      builders: ${{ steps.builders.outputs.builders }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Get builders from integration.json
+      id: builders
+      run: |
+        source "${{ github.workspace }}/scripts/.util/builders.sh"
+
+        builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
+        printf "Output: %s\n" "${builders}"
+        printf "::set-output name=builders::%s\n" "${builders}"
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
+    needs: [builders]
+    strategy:
+      matrix:
+        builder: ${{ fromJSON(needs.builders.outputs.builders) }}
+      fail-fast: false  # don't cancel all test jobs when one fails
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -27,7 +48,7 @@ jobs:
       uses: actions/checkout@v3
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
     - name: Run Integration Tests
-      run: ./scripts/integration.sh
+      run: ./scripts/integration.sh --builder ${{ matrix.builder }}
 
   release:
     name: Release

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         printf "::set-output name=builders::%s\n" "${builders}"
 
   integration:
-    name: Integration Tests
+    name: Integration Tests with Builders
     runs-on: ubuntu-latest
     needs: [builders]
     strategy:
@@ -49,6 +49,15 @@ jobs:
 
     - name: Run Integration Tests
       run: ./scripts/integration.sh --builder ${{ matrix.builder }}
+
+  roundup:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+    - run: |
+        echo "Integration tests passed against all builders"
+        exit 0
 
   upload:
     name: Upload Workflow Event Payload


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The change in #503 had an unintended side effect. PRs [stall](https://github.com/paketo-buildpacks/dotnet-core-sdk/pull/377) waiting for the `Integration Tests` job to run, since it's a required check. Github's branch protection rules match required checks by name. The new matrix strategy changed the name of integration test jobs. 

One solution would be to manually update the required checks for all ~100 paketo buildpack repos. This work would have to be repeated whenever we add a builder to our test matrix. 

This PR offers an alternative: a job that `needs` the matrix-ed integration tests and has the same old name, `Integration Tests`. This job is therefore already marked required on most repos. With this addition, existing branch protection rules will continue to work.

This PR also adds the parallel matrix strategy to integration testing during the release process. This should speed up release pipelines for buildpacks that test against multiple builders.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
