### PR TITLE
Add --unbuffered option to stack creation script.

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -142,7 +142,15 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create stack
-      run: ./scripts/create.sh
+      run: |
+        # If the repository name contains 'full' then we create the stack with
+        # the --unbuffered flag to avoid hitting memory limits in github
+        # workers
+        if [[ ${{ github.repository }} == *-"full"-* ]]; then
+          ./scripts/create.sh --unbuffered
+        else
+          ./scripts/create.sh
+        fi
 
     - name: Generate Package Receipts
       id: receipts

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -18,8 +18,19 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Create stack
+      run: |
+        # If the repository name contains 'full' then we create the stack with
+        # the --unbuffered flag to avoid hitting memory limits in github
+        # workers
+        if [[ ${{ github.repository }} == *-"full"-* ]]; then
+          ./scripts/create.sh --unbuffered
+        else
+          ./scripts/create.sh
+        fi
+
     - name: Run Acceptance Tests
-      run: ./scripts/test.sh --clean
+      run: ./scripts/test.sh
 
   upload:
     name: Upload Workflow Event Payload

--- a/stack/scripts/create.sh
+++ b/stack/scripts/create.sh
@@ -16,12 +16,21 @@ source "${PROG_DIR}/.util/tools.sh"
 source "${PROG_DIR}/.util/print.sh"
 
 function main() {
+  local unbuffered
+
+  unbuffered="false"
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --help|-h)
         shift 1
         usage
         exit 0
+        ;;
+
+      --unbuffered)
+        unbuffered="true"
+        shift 1
         ;;
 
       "")
@@ -37,7 +46,7 @@ function main() {
   mkdir -p "${BUILD_DIR}"
 
   tools::install
-  stack::create
+  stack::create "${unbuffered}"
 }
 
 function usage() {
@@ -48,9 +57,11 @@ Creates the stack using the descriptor, build and run Dockerfiles in
 the repository.
 
 OPTIONS
-  --help  -h  prints the command usage
+  --help       -h   prints the command usage
+  --unbuffered      do not buffer image contents into memory for fast access
 USAGE
 }
+
 
 function tools::install() {
   util::tools::jam::install \
@@ -58,11 +69,20 @@ function tools::install() {
 }
 
 function stack::create() {
+  local unbuffered
+
+  unbuffered="${1}"
+
+  if [[ "${unbuffered}" == "true" ]]; then
+    echo "Running in unbuffered mode - this may take substantially longer"
+    echo
+  fi
 
   jam create-stack \
       --config "${STACK_DIR}/stack.toml" \
       --build-output "${BUILD_DIR}/build.oci" \
-      --run-output "${BUILD_DIR}/run.oci"
+      --run-output "${BUILD_DIR}/run.oci" \
+      --unbuffered="${unbuffered}"
 }
 
 main "${@:-}"


### PR DESCRIPTION
Signed-off-by: Sophie Wigmore <swigmore@vmware.com>

## Summary
This PR adds support for the `--unbuffered` flag to the `jam create-stack` command for the `*-full-stack` repos (i.e `jammy-full-stack` and `bionic-full-stack`). This flag reduces memory usage for large stacks, meaning that we don't have to increase the swap size on resource constrained environments (e.g. github actions workers).

We have tested both code flows in the `jammy-full-stack` and `jammy-tiny-stack` and they both create the images succesfully.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
