### PR TITLE
Reopen existing auto-filed issues

### DIFF
--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -60,7 +60,8 @@ runs:
         release_issue=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --json number --jq .[0].number)
 
         if [ -n "${release_issue}" ]; then
-          gh issue reopen "${release_issue}"
+          gh issue reopen "${release_issue}" \
+            --repo "${{ inputs.repo }}"
           gh issue comment "${release_issue}" \
             --body "${{ inputs.comment_body }}" \
             --repo "${{ inputs.repo }}"

--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -57,9 +57,10 @@ runs:
           exit 1
         fi
 
-        release_issue=$(gh issue list --repo "${{ inputs.repo }}" --json number --label "${{ inputs.label }}" --jq .[0].number)
+        release_issue=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --json number --jq .[0].number)
 
         if [ -n "${release_issue}" ]; then
+          gh issue reopen "${release_issue}"
           gh issue comment "${release_issue}" \
             --body "${{ inputs.comment_body }}" \
             --repo "${{ inputs.repo }}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The auto-file automation creates a bunch of short-lived issues [like this one](https://github.com/paketo-buildpacks/dotnet-core-runtime/issues/361) because the search for existing issues doesn't account for closed issues. With this change, if `comment_if_exists` is true, the automation will look for open or closed issues with the desired tag. It will reopen the most recent tagged issue and then comment on it. 

🔍  Note: `gh issue reopen` exits 0 if the issue is already open, so there's no need to check the state of the issue.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
