### PR TITLE
Stacks: Push Bionic run images to GCR

### DIFF
--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -43,14 +43,14 @@ jobs:
         echo "::set-output name=name::$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')"
 
     - name: Setup gcloud
-      if: ${{ steps.registry-repo.outputs.name == "bionic"-* }}
+      if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
       uses: google-github-actions/setup-gcloud@master
       with:
         version: '270.0.0'
         service_account_key: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
 
     - name: Configure docker gcloud auth
-      if: ${{ steps.registry-repo.outputs.name == "bionic"-* }}
+      if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
       run: gcloud auth configure-docker gcr.io
 
     - name: Push to DockerHub
@@ -74,7 +74,8 @@ jobs:
         #    paketobuildpacks/{build/run}:{variant}-cnb
         #    paketobuildpacks/{build/run}:{variant}
         # Also push a bionic run image to GCR as a legacy run image mirror
-        if [[ ${{ steps.registry-repo.outputs.name }} == "bionic"-* ]];
+        registry_repo="${{ steps.registry-repo.outputs.name }}"
+        if [[ ${registry_repo} == "bionic"-* ]];
           then
           # Strip the final part from a repo name after the `-`
           # bionic-tiny --> tiny

--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -35,6 +35,24 @@ jobs:
         output: "/github/workspace/run.oci"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
+    - name: Get Registry Repo Name
+      id: registry-repo
+      run: |
+        # Strip off the Github org prefix and 'stack' suffix from repo name
+        # paketo-buildpacks/some-name-stack --> some-name
+        echo "::set-output name=name::$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')"
+
+    - name: Setup gcloud
+      if: ${{ steps.registry-repo.outputs.name == "bionic"-* }}
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        version: '270.0.0'
+        service_account_key: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+
+    - name: Configure docker gcloud auth
+      if: ${{ steps.registry-repo.outputs.name == "bionic"-* }}
+      run: gcloud auth configure-docker
+
     - name: Push to DockerHub
       id: push
       env:
@@ -44,22 +62,19 @@ jobs:
       run: |
         echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin index.docker.io
 
-        # Strip off the Github org prefix and 'stack' suffix from repo name
-        # paketo-buildpacks/some-name-stack --> some-name
-        registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:latest"
 
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${registry_repo}:${{ steps.event.outputs.tag }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${registry_repo}:latest"
-
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${registry_repo}:${{ steps.event.outputs.tag }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${registry_repo}:latest"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:latest"
 
         # If the repository name contains 'bionic', let's push it to legacy image locations as well:
         #    paketobuildpacks/{build/run}:{version}-{variant}
         #    paketobuildpacks/{build/run}:{version}-{variant}-cnb
         #    paketobuildpacks/{build/run}:{variant}-cnb
         #    paketobuildpacks/{build/run}:{variant}
-        if [[ ${registry_repo} == "bionic"-* ]];
+        # Also push a bionic run image to GCR as a legacy run image mirror
+        if [[ ${{ steps.registry-repo.outputs.name }} == "bionic"-* ]];
           then
           # Strip the final part from a repo name after the `-`
           # bionic-tiny --> tiny
@@ -74,6 +89,8 @@ jobs:
           sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${{ steps.event.outputs.tag }}-${variant}-cnb"
           sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${variant}-cnb"
           sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${variant}"
+
+          sudo skopeo copy "docker://${DOCKERHUB_ORG}/run:${variant}-cnb" "docker://gcr.io/paketo-buildpacks/run:${variant}-cnb"
         fi
 
 

--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Configure docker gcloud auth
       if: ${{ steps.registry-repo.outputs.name == "bionic"-* }}
-      run: gcloud auth configure-docker
+      run: gcloud auth configure-docker gcr.io
 
     - name: Push to DockerHub
       id: push


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

We should continue pushing the run image mirrors to GCR for Bionic only, since the builders reference this location.

This will  resolve issues like https://github.com/paketo-buildpacks/full-builder/issues/709 for future stack releases.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
