### PR TITLE
Stacks: use setup-gcloud action from main

### DIFF
--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Setup gcloud
       if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@main
       with:
         version: '270.0.0'
         service_account_key: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Fix the `setup-gcloud`  workflow set to be picked up from `main` instead of `master`. It will resolve issues like
https://github.com/paketo-buildpacks/jammy-full-stack/issues/17 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
