### PR TITLE
Fix issue-opening action

### DIFF
--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -45,7 +45,6 @@ runs:
 
       gh auth status
 
-      release_issue=""
       if [[ "${{ inputs.comment_if_exists }}" == "true" ]]; then
         if [ -z "${{ inputs.label }}" ]; then
           echo "must provide 'label' as input when 'comment_if_exists' is true"
@@ -57,12 +56,14 @@ runs:
           exit 1
         fi
 
-        release_issue=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --json number --jq .[0].number)
+        # if there is already an issue with the same title, then comment
+        # the failure on that issue, rather than opening a new issue.
+        issue_number=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --search "${{ inputs.issue_title }}" --json number --jq .[0].number)
 
-        if [ -n "${release_issue}" ]; then
-          gh issue reopen "${release_issue}" \
+        if [ -n "${issue_number}" ]; then
+          gh issue reopen "${issue_number}" \
             --repo "${{ inputs.repo }}"
-          gh issue comment "${release_issue}" \
+          gh issue comment "${issue_number}" \
             --body "${{ inputs.comment_body }}" \
             --repo "${{ inputs.repo }}"
           exit 0


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

In https://github.com/paketo-buildpacks/dep-server/issues/196, we saw an example of a workflow failure issue being reopened by GHA even though the dependencies of interest were different. This change makes it so that if an issue is reopened and/or commented on, the issue title must be what we expect it to be as well.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
