### PR TITLE
Add exponential backoff failure handling to create-release file uploading

### DIFF
--- a/actions/release/create/entrypoint/go.mod
+++ b/actions/release/create/entrypoint/go.mod
@@ -3,6 +3,7 @@ module github.com/paketo-buildpacks/github-config/actions/release/create/entrypo
 go 1.14
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/onsi/gomega v1.20.0
 	github.com/sclevine/spec v1.4.0
 )

--- a/actions/release/create/entrypoint/go.sum
+++ b/actions/release/create/entrypoint/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
## Summary

This PR adds support for retrying file uploads during the release creation step. It uses exponential backoff, using https://github.com/paketo-buildpacks/github-config/pull/488 as an example.

The main motivation for this PR is the observation that the majority of workflow failures (outside of test failures) stem from errors that occur during upload of files during the release creation step. This seems to happen most often with the larger `tgz`/`cnb` files that comprise the buildpacks and stacks.

I have tested this logic locally by extracting this logic into a small `main.go` and I have observed that it retries on failure as expected. Additionally, I have validated that the upload can eventually succeed without issues (e.g. due to re-opening the file).

The commit looks like there are a lot of changes, but really it's just wrapping the existing code in the backoff function and hence is mostly indentation changes.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
