### PR TITLE
Change auth method to login into docker using gcr.io

### DIFF
--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -42,16 +42,13 @@ jobs:
         # paketo-buildpacks/some-name-stack --> some-name
         echo "::set-output name=name::$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')"
 
-    - name: Setup gcloud
+    - name: Login to GCR
       if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
-      uses: google-github-actions/setup-gcloud@main
+      uses: docker/login-action@v2
       with:
-        version: '270.0.0'
-        service_account_key: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
-
-    - name: Configure docker gcloud auth
-      if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
-      run: gcloud auth configure-docker
+        registry: gcr.io
+        username: _json_key
+        password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
 
     - name: Push to DockerHub
       id: push


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Some stack Push actions are failing like [this](https://github.com/paketo-buildpacks/bionic-base-stack/actions/runs/2799074651) using the `gcloud auth` and `gcloud auth configure-docker gcr.io`.

This change simplifies both commands using the official Docker Login [Github Action](https://github.com/docker/login-action) to access the Paketo Buildpacks GCR Repository (these changes only applies to Bionic stacks)

Solves https://github.com/paketo-buildpacks/bionic-base-stack/issues/24, https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/7, https://github.com/paketo-buildpacks/bionic-full-stack/issues/18

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
