### PR TITLE
add go.mod and go.sum to implementation patch list

### DIFF
--- a/implementation/.github/.patch_files
+++ b/implementation/.github/.patch_files
@@ -25,3 +25,5 @@ scripts/.util/tools.sh
 scripts/.util/builders.sh
 scripts/integration.sh
 scripts/unit.sh
+go.mod
+go.sum

--- a/implementation/.github/workflows/go-get-update.yml
+++ b/implementation/.github/workflows/go-get-update.yml
@@ -2,7 +2,7 @@ name: Go Get Update
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Once a day at midnight
+    - cron: '0 0 * * 1'  # Once per week, Mondays at midnight
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Manually labeling tons of `Running 'go get -u all'`PRs  is getting tedious. It would be nice if these PRs auto-labeled and thus auto-merged. 

Edit: I have also modified the workflow to run once per week, rather than once per day.

Maintainer question - could it be dangerous to always auto-label `go.mod` changes as patches? Any package bumps that are breaking should hopefully cause linting or test failures which is why I think this is fine.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
