### PR TITLE
Use max time rather than max attemps for exponential backoff.

### DIFF
--- a/actions/release/create/entrypoint/main.go
+++ b/actions/release/create/entrypoint/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.StringVar(&config.Release.Body, "body", "", "Contents of release body")
 	flag.BoolVar(&config.Draft, "draft", false, "Sets the release as a draft")
 	flag.StringVar(&config.Assets, "assets", "", "JSON-encoded assets metadata")
-	flag.StringVar(&config.RetryTimeLimit, "retry-time-limit", "5m", "How long to retry failures for")
+	flag.StringVar(&config.RetryTimeLimit, "retry-time-limit", "1m", "How long to retry failures for")
 	flag.Parse()
 
 	if config.Repo == "" {

--- a/actions/release/create/entrypoint/main.go
+++ b/actions/release/create/entrypoint/main.go
@@ -124,6 +124,8 @@ func main() {
 		uri.Path = fmt.Sprintf("/repos/%s/releases/%d/assets", config.Repo, release.ID)
 		uri.RawQuery = url.Values{"name": []string{asset.Name}}.Encode()
 
+		exponentialBackoff := backoff.NewExponentialBackOff()
+		exponentialBackoff.MaxElapsedTime = 5 * time.Minute
 		err = backoff.RetryNotify(func() error {
 			file, err := os.Open(asset.Path)
 			if err != nil {
@@ -158,10 +160,10 @@ func main() {
 
 			return nil
 		},
-			backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3),
+			exponentialBackoff,
 			func(err error, t time.Duration) {
 				fmt.Println(err)
-				fmt.Printf("Retrying in %s seconds\n", t)
+				fmt.Printf("Retrying in %s\n", t)
 			},
 		)
 

--- a/actions/release/create/entrypoint/main_test.go
+++ b/actions/release/create/entrypoint/main_test.go
@@ -370,6 +370,32 @@ func TestEntrypoint(t *testing.T) {
 		})
 
 		context("failure cases", func() {
+			context("when the retry time limit is an invalid duration", func() {
+				it("prints an error and exits non-zero", func() {
+					command := exec.Command(
+						entrypoint,
+						"--retry-time-limit", "unparsable",
+						"--repo", "some-org/some-repo",
+						"--endpoint", api.URL,
+						"--token", "some-github-token",
+						"--tag-name", "some-tag",
+						"--target-commitish", "some-commitish",
+						"--name", "some-name",
+						"--body", "some-body",
+					)
+
+					buffer := gbytes.NewBuffer()
+
+					session, err := gexec.Start(command, buffer, buffer)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(session).Should(gexec.Exit(1), func() string { return fmt.Sprintf("output -> \n%s\n", buffer.Contents()) })
+
+					Expect(buffer).To(gbytes.Say(`Error: time: invalid duration "unparsable"`))
+				})
+
+			})
+
 			context("when missing the repo flag", func() {
 				it("prints an error and exits non-zero", func() {
 					command := exec.Command(
@@ -641,6 +667,7 @@ func TestEntrypoint(t *testing.T) {
 				it("prints an error and exits non-zero", func() {
 					command := exec.Command(
 						entrypoint,
+						"--retry-time-limit", "1s",
 						"--endpoint", api.URL,
 						"--repo", "some-org/some-repo",
 						"--token", "some-github-token",
@@ -687,6 +714,7 @@ func TestEntrypoint(t *testing.T) {
 				it("prints an error and exits non-zero", func() {
 					command := exec.Command(
 						entrypoint,
+						"--retry-time-limit", "1s",
 						"--endpoint", api.URL,
 						"--repo", "some-org/some-upload-redirect-repo",
 						"--token", "some-github-token",
@@ -733,6 +761,7 @@ func TestEntrypoint(t *testing.T) {
 				it("prints an error and exits non-zero", func() {
 					command := exec.Command(
 						entrypoint,
+						"--retry-time-limit", "1s",
 						"--endpoint", api.URL,
 						"--repo", "some-org/some-upload-error-repo",
 						"--token", "some-github-token",

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -43,11 +43,12 @@ type CVE struct {
 
 func main() {
 	var config struct {
-		Distro       string
-		LastUSNsJSON string
-		Output       string
-		PackagesJSON string
-		RSSURL       string
+		Distro         string
+		LastUSNsJSON   string
+		Output         string
+		PackagesJSON   string
+		RSSURL         string
+		RetryTimeLimit string
 	}
 
 	flag.StringVar(&config.LastUSNsJSON,
@@ -71,6 +72,8 @@ func main() {
 		"",
 		"Path to output JSON file")
 
+	flag.StringVar(&config.RetryTimeLimit, "retry-time-limit", "5m", "How long to retry failures for")
+
 	flag.Parse()
 
 	if config.LastUSNsJSON == "" {
@@ -81,8 +84,13 @@ func main() {
 		config.PackagesJSON = `[]`
 	}
 
+	retryTimeLimit, err := time.ParseDuration(config.RetryTimeLimit)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	var lastUSNs []USN
-	err := json.Unmarshal([]byte(config.LastUSNsJSON), &lastUSNs)
+	err = json.Unmarshal([]byte(config.LastUSNsJSON), &lastUSNs)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -93,7 +101,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	newUSNs, err := getNewUSNsFromFeed(config.RSSURL, lastUSNs, distroToVersionRegex[config.Distro])
+	newUSNs, err := getNewUSNsFromFeed(config.RSSURL, lastUSNs, distroToVersionRegex[config.Distro], retryTimeLimit)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -172,14 +180,14 @@ func addCVEs(usn *USN) error {
 	return nil
 }
 
-func getNewUSNsFromFeed(rssURL string, lastUSNs []USN, distro string) ([]USN, error) {
+func getNewUSNsFromFeed(rssURL string, lastUSNs []USN, distro string, retryTimeLimit time.Duration) ([]USN, error) {
 	fp := gofeed.NewParser()
 
 	var feed *gofeed.Feed
 	var err error
 
 	exponentialBackoff := backoff.NewExponentialBackOff()
-	exponentialBackoff.MaxElapsedTime = 5 * time.Minute
+	exponentialBackoff.MaxElapsedTime = retryTimeLimit
 	err = backoff.RetryNotify(func() error {
 		feed, err = fp.ParseURL(rssURL)
 		if err == nil {


### PR DESCRIPTION
## Summary

This PR changes the way we leverage exponential backoff to continue attempting the task until a duration is exceed (max time) rather than until a specific number of attempts have been made (max retries). This better aligns with what we care about - namely how long we have been trying to perform an action rather than how many times we have attempted it.

The change from 3 retries to 5 minutes also substantially increases how long we are willing to wait for a task to complete. In particular, we have observed that getting `503` while looking for USNs can take minutes, not seconds, to being working again. This will result in fewer failures getting USNs. Changing the create-release file upload is not necessary, but is done to reduce the cognitive overhead of having different limits on tasks with exponential backoff retries.

I also fixed the printing of how long we will wait until the next iteration as previously it was saying:

```
Retrying in 552.330144ms seconds
```

I had to make the timeout configurable to be able to integration test it, but I don't think it's particularly useful otherwise. If you have better suggestions as to how to make that timeout lower only for integration tests I'm all ears.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
