### PR TITLE
Use url instead of brower_download_url when downloading release assets.

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -58,7 +58,7 @@ function find_asset() {
     | jq -r \
     --arg pattern "${pattern}" \
     --argjson depth "${depth}" \
-    '[ limit($depth; .[] | select( .draft == false )) | .assets | .[] | select(.name | test($pattern)) | .browser_download_url][0]' )
+    '[ limit($depth; .[] | select( .draft == false )) | .assets | .[] | select(.name | test($pattern)) | .url][0]' )
 
   if [[ "${url}" == "null" ]]; then
       if [[ "${strict}" == "true" ]]; then


### PR DESCRIPTION
## Summary

The `browser_download_url` does not allow programatic access to assets from private repos. Instead we should use `url` which works equally well for release assets on public and private repositories.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
