### PR TITLE
Increase the verbosity of rsync in the sync action

### DIFF
--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -38,7 +38,7 @@ function main() {
 
     local args=(
       --recursive
-      --verbose
+      -vv
       --checksum
       "${src}"
       "${dest}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
According to the `rsync` manpage, "Two -v options will give you information on what files are being skipped and slightly more information at the end."

## Use Cases
<!-- An explanation of the use cases your change enables -->
When debugging why a `.syncignore` file is not working, it would be nice to see what `rsync` says it is doing.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).