### PR TITLE
Fail on curl errors

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -20,6 +20,8 @@ runs:
       set -eu
       version="$(
         curl "https://api.github.com/repos/paketo-buildpacks/jam/releases/latest" \
+          --fail-with-body \
+          --show-error \
           --header "Authorization: token ${{ inputs.token }}" \
           --location \
           --silent \
@@ -36,6 +38,8 @@ runs:
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
       curl "https://github.com/paketo-buildpacks/jam/releases/download/v${{ steps.version.outputs.version }}/jam-linux" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "${HOME}/bin/jam"

--- a/actions/buildpack/update/action.yml
+++ b/actions/buildpack/update/action.yml
@@ -36,6 +36,8 @@ runs:
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
       curl "https://github.com/paketo-buildpacks/jam/releases/download/v${{ steps.version.outputs.version }}/jam-linux" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "${HOME}/bin/jam"

--- a/actions/dependency/update/action.yml
+++ b/actions/dependency/update/action.yml
@@ -30,6 +30,8 @@ runs:
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
       curl "https://github.com/paketo-buildpacks/jam/releases/download/v${{ steps.version.outputs.version }}/jam-linux" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "${HOME}/bin/jam"

--- a/actions/pull-request/approve/Dockerfile
+++ b/actions/pull-request/approve/Dockerfile
@@ -12,6 +12,8 @@ ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "/tmp/gh.tgz" \

--- a/actions/pull-request/check-human-commits/entrypoint
+++ b/actions/pull-request/check-human-commits/entrypoint
@@ -53,6 +53,8 @@ function rules::has_human_commits() {
   IFS="," read -r -a bots <<< "${4}"
   IFS=" " read -r -a committers <<< "$(
     curl "https://api.github.com/repos/${repo}/pulls/${number}/commits" \
+      --fail-with-body \
+      --show-error \
       --silent \
       --location \
       --header "Authorization: token ${token}" \

--- a/actions/pull-request/check-unverified-commits/entrypoint
+++ b/actions/pull-request/check-unverified-commits/entrypoint
@@ -48,6 +48,8 @@ function rules::has_unverified_commits() {
 
   IFS=" " read -r -a verified <<< "$(
     curl "https://api.github.com/repos/${repo}/pulls/${number}/commits" \
+      --fail-with-body \
+      --show-error \
       --silent \
       --location \
       --header "Authorization: token ${token}" \
@@ -56,6 +58,8 @@ function rules::has_unverified_commits() {
 
   IFS=" " read -r -a committers <<< "$(
     curl "https://api.github.com/repos/${repo}/pulls/${number}/commits" \
+      --fail-with-body \
+      --show-error \
       --silent \
       --location \
       --header "Authorization: token ${token}" \

--- a/actions/pull-request/merge/Dockerfile
+++ b/actions/pull-request/merge/Dockerfile
@@ -12,6 +12,8 @@ ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "/tmp/gh.tgz" \

--- a/actions/pull-request/open/Dockerfile
+++ b/actions/pull-request/open/Dockerfile
@@ -13,6 +13,8 @@ ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "/tmp/gh.tgz" \

--- a/actions/pull-request/rebase/Dockerfile
+++ b/actions/pull-request/rebase/Dockerfile
@@ -12,6 +12,8 @@ ARG gh_version=1.7.0
 RUN mkdir -p "/bin" \
       && export PATH="${PATH}:/bin" \
       && curl "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
+        --fail-with-body \
+        --show-error \
         --silent \
         --location \
         --output "/tmp/gh.tgz" \

--- a/actions/release/download-asset/entrypoint
+++ b/actions/release/download-asset/entrypoint
@@ -38,6 +38,8 @@ function main() {
 
   echo "Downloading ${url}"
   curl "${url}" \
+    --fail-with-body \
+    --show-error \
     --header "Authorization: token ${token}" \
     --header "Accept: application/octet-stream" \
     --silent \

--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -46,6 +46,8 @@ function main() {
   local jam_version
   jam_version="$(
     curl "https://api.github.com/repos/paketo-buildpacks/jam/releases/latest" \
+      --fail-with-body \
+      --show-error \
       --header "Authorization: token ${token}" \
       --location \
       --silent \
@@ -55,6 +57,8 @@ function main() {
   mkdir -p "${HOME}"/bin
   export PATH="${HOME}/bin:${PATH}"
   curl "https://github.com/paketo-buildpacks/jam/releases/download/${jam_version}/jam-linux" \
+    --fail-with-body \
+    --show-error \
     --silent \
     --location \
     --output "${HOME}/bin/jam"
@@ -70,6 +74,8 @@ function main() {
   local version
   version="$(
     curl "https://api.github.com/repos/${repo}/releases/latest" \
+      --fail-with-body \
+      --show-error \
       --header "Authorization: token ${token}" \
       --location \
       --silent \
@@ -79,6 +85,8 @@ function main() {
   if [[ "${version}" != "null" ]]; then
     IFS=$'\n' read -r -d '' -a commits < <(
       curl "https://api.github.com/repos/${repo}/compare/${version}...main" \
+        --fail-with-body \
+        --show-error \
         --header "Authorization: token ${token}" \
         --location \
         --silent \
@@ -90,6 +98,8 @@ function main() {
     changes="$(
       for commit in "${commits[@]}"; do
         curl "https://api.github.com/repos/${repo}/commits/${commit}/pulls" \
+          --fail-with-body \
+          --show-error \
           --header "Accept: application/vnd.github.groot-preview+json" \
           --header "Authorization: token ${token}" \
           --location \

--- a/actions/tools/latest/entrypoint
+++ b/actions/tools/latest/entrypoint
@@ -38,6 +38,8 @@ function main() {
   local version
   version="$(
     curl "https://api.github.com/repos/${repo}/releases/latest" \
+      --fail-with-body \
+      --show-error \
       --header "Authorization: token ${token}" \
       --silent \
       --location \

--- a/scripts/change_version.sh
+++ b/scripts/change_version.sh
@@ -64,7 +64,7 @@ function change_draft_release_version() {
   token="${3}"
 
   util::print::info "getting current draft release..."
-  draft_id=$(curl --silent -XGET \
+  draft_id=$(curl --fail-with-body --show-error --silent -XGET \
     "https://api.github.com/repos/${repo}/releases" \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Authorization: token ${token}" \
@@ -76,7 +76,7 @@ function change_draft_release_version() {
     util::print::error "this script relies on the repo having an existing draft release"
   else
     util::print::info "editing draft release..."
-    curl --silent -XPATCH \
+    curl --fail-with-body --show-error --silent -XPATCH \
       "https://api.github.com/repos/${repo}/releases/${draft_id}" \
       --header "Accept: application/vnd.github.v3+json" \
       --header "Authorization: token ${token}" \
@@ -92,6 +92,8 @@ function generate_new_draft_release() {
 
   util::print::info "kicking off release process..."
   curl \
+    --fail-with-body \
+    --show-error \
     -X POST \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Authorization: token ${token}" \

--- a/scripts/clone-all-repos.sh
+++ b/scripts/clone-all-repos.sh
@@ -121,6 +121,8 @@ function teams::fetch() {
   util::print::yellow "  Fetching teams belonging to the ${org} GitHub organization..."
 
   curl "https://api.github.com/orgs/${org}/teams?per_page=100" \
+    --fail-with-body \
+    --show-error \
     --silent --location \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Authorization: token ${token}" \
@@ -137,6 +139,8 @@ function teams::repos::fetch() {
   util::print::yellow "  Fetching repos belonging to the @${org}/${team} GitHub team..."
 
   curl "${url}" \
+    --fail-with-body \
+    --show-error \
     --silent --location \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Authorization: token ${token}" \

--- a/scripts/repo_rules.sh
+++ b/scripts/repo_rules.sh
@@ -99,6 +99,8 @@ function rules() {
 
   json="$(
     curl "https://api.github.com/repos/${repo}/branches/${branch}/protection" \
+      --fail-with-body \
+      --show-error \
       --silent \
       --request GET \
       --header "Accept: application/vnd.github.luke-cage-preview+json" \


### PR DESCRIPTION
## Summary

This PR ensures that curl returns a non-zero exit code when there is a server error (e.g. 404). It also forces the printing of the error message to aid debugging of a failed curl invocation.

## Use Cases

Currently, when an invocation of `curl` fails, if fails silently - proceeding on to the next part of the action/workflow. The failure therefore only shows up in an unrelated command that is trying to do something with the result of the curl (e.g. invoking a downloaded binary or reading a downloaded file).

It can be hard to recognize these failures as a `curl` failure, and, more importantly, we should fail the action/workflow at the point that `curl` fails, not later on.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
