### PR TITLE
Run workflows on ubuntu 22.04 (jammy).

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lintYaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -11,7 +11,7 @@ concurrency: tools_update
 jobs:
   update:
     name: Update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/builder/.github/workflows/approve-bot-pr.yml
+++ b/builder/.github/workflows/approve-bot-pr.yml
@@ -10,7 +10,7 @@ jobs:
   download:
     name: Download PR Artifact
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
@@ -32,7 +32,7 @@ jobs:
     name: Approve Bot PRs
     needs: download
     if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Commit Verification
       id: unverified-commits

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -10,7 +10,7 @@ concurrency: release
 jobs:
   smoke:
     name: Smoke Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       release_notes: ${{ steps.notes.outputs.body }}
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: smoke
     steps:
     - name: Checkout With History
@@ -97,7 +97,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ smoke, release ]
     if: ${{ always() && needs.smoke.result == 'failure' ||  needs.release.result == 'failure' }}
     steps:

--- a/builder/.github/workflows/lint-yaml.yml
+++ b/builder/.github/workflows/lint-yaml.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lintYaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/builder/.github/workflows/push-image.yml
+++ b/builder/.github/workflows/push-image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Parse Event

--- a/builder/.github/workflows/synchronize-labels.yml
+++ b/builder/.github/workflows/synchronize-labels.yml
@@ -9,7 +9,7 @@ jobs:
     synchronize:
         name: Synchronize Labels
         runs-on:
-            - ubuntu-latest
+            - ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1

--- a/builder/.github/workflows/test-builder.yml
+++ b/builder/.github/workflows/test-builder.yml
@@ -7,7 +7,7 @@ jobs:
 
   smoke:
     name: Smoke Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/builder/.github/workflows/test-pull-request.yml
+++ b/builder/.github/workflows/test-pull-request.yml
@@ -9,7 +9,7 @@ jobs:
 
   smoke:
     name: Smoke Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -24,7 +24,7 @@ jobs:
 
   upload:
     name: Upload Workflow Event Payload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -10,7 +10,7 @@ concurrency: builder_update
 jobs:
   update:
     name: Update builder.toml
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out
       uses: actions/checkout@v3

--- a/builder/.github/workflows/update-github-config.yml
+++ b/builder/.github/workflows/update-github-config.yml
@@ -10,7 +10,7 @@ concurrency: github_config_update
 jobs:
   build:
     name: Create PR to update shared files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout

--- a/implementation/.github/workflows/approve-bot-pr.yml
+++ b/implementation/.github/workflows/approve-bot-pr.yml
@@ -10,7 +10,7 @@ jobs:
   download:
     name: Download PR Artifact
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
@@ -32,7 +32,7 @@ jobs:
     name: Approve Bot PRs
     needs: download
     if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Commit Verification
       id: unverified-commits

--- a/implementation/.github/workflows/codeql-analysis.yml
+++ b/implementation/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -17,7 +17,7 @@ concurrency: release
 jobs:
   unit:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       builders: ${{ steps.builders.outputs.builders }}
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: unit
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: integration
     steps:
     - name: Setup Go
@@ -126,7 +126,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ unit, integration, release ]
     if: ${{ always() && needs.unit.result == 'failure' || needs.integration.result == 'failure' || needs.release.result == 'failure' }}
     steps:

--- a/implementation/.github/workflows/go-get-update.yml
+++ b/implementation/.github/workflows/go-get-update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update:
     name: Go Get Update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/implementation/.github/workflows/label-pr.yml
+++ b/implementation/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@ concurrency: pr_labels_${{ github.event.number }}
 jobs:
   autolabel:
     name: Ensure Minimal Semver Labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Minimal Semver Labels
       uses: mheap/github-action-required-labels@v1

--- a/implementation/.github/workflows/lint-yaml.yml
+++ b/implementation/.github/workflows/lint-yaml.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lintYaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/implementation/.github/workflows/lint.yml
+++ b/implementation/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Parse Event
@@ -76,7 +76,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [push]
     if: ${{ always() && needs.push.result == 'failure' }}
     steps:

--- a/implementation/.github/workflows/synchronize-labels.yml
+++ b/implementation/.github/workflows/synchronize-labels.yml
@@ -9,7 +9,7 @@ jobs:
     synchronize:
         name: Synchronize Labels
         runs-on:
-            - ubuntu-latest
+            - ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   unit:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       builders: ${{ steps.builders.outputs.builders }}
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   integration:
     name: Integration Tests with Builders
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: unit
     strategy:
       matrix:
@@ -63,7 +63,7 @@ jobs:
 
   roundup:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: integration
     steps:
     - run: |
@@ -72,7 +72,7 @@ jobs:
 
   upload:
     name: Upload Workflow Event Payload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/implementation/.github/workflows/update-dependencies.yml
+++ b/implementation/.github/workflows/update-dependencies.yml
@@ -9,7 +9,7 @@ concurrency: dependency_update
 
 jobs:
   update-dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Update dependencies
     steps:
 

--- a/implementation/.github/workflows/update-github-config.yml
+++ b/implementation/.github/workflows/update-github-config.yml
@@ -10,7 +10,7 @@ concurrency: github_config_update
 jobs:
   build:
     name: Create PR to update shared files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout

--- a/language-family/.github/workflows/approve-bot-pr.yml
+++ b/language-family/.github/workflows/approve-bot-pr.yml
@@ -10,7 +10,7 @@ jobs:
   download:
     name: Download PR Artifact
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
@@ -32,7 +32,7 @@ jobs:
     name: Approve Bot PRs
     needs: download
     if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Commit Verification
       id: unverified-commits

--- a/language-family/.github/workflows/create-draft-release.yml
+++ b/language-family/.github/workflows/create-draft-release.yml
@@ -17,7 +17,7 @@ concurrency: release
 jobs:
   builders:
     name: Get Builders for Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       builders: ${{ steps.builders.outputs.builders }}
     steps:
@@ -33,7 +33,7 @@ jobs:
         printf "::set-output name=builders::%s\n" "${builders}"
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [builders]
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: integration
     steps:
     - name: Checkout
@@ -109,7 +109,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ integration, release ]
     if: ${{ always() && needs.integration.result == 'failure' || needs.release.result == 'failure' }}
     steps:

--- a/language-family/.github/workflows/label-pr.yml
+++ b/language-family/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@ concurrency: pr_labels_${{ github.event.number }}
 jobs:
   autolabel:
     name: Ensure Minimal Semver Labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Minimal Semver Labels
       uses: mheap/github-action-required-labels@v1

--- a/language-family/.github/workflows/lint-yaml.yml
+++ b/language-family/.github/workflows/lint-yaml.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lintYaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/language-family/.github/workflows/lint.yml
+++ b/language-family/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/language-family/.github/workflows/push-buildpackage.yml
+++ b/language-family/.github/workflows/push-buildpackage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Parse Event
@@ -76,7 +76,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [push]
     if: ${{ always() && needs.push.result == 'failure' }}
     steps:

--- a/language-family/.github/workflows/synchronize-labels.yml
+++ b/language-family/.github/workflows/synchronize-labels.yml
@@ -9,7 +9,7 @@ jobs:
     synchronize:
         name: Synchronize Labels
         runs-on:
-            - ubuntu-latest
+            - ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   builders:
     name: Get Builders for Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       builders: ${{ steps.builders.outputs.builders }}
     steps:
@@ -30,7 +30,7 @@ jobs:
 
   integration:
     name: Integration Tests with Builders
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [builders]
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   roundup:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: integration
     steps:
     - run: |
@@ -61,7 +61,7 @@ jobs:
 
   upload:
     name: Upload Workflow Event Payload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -9,7 +9,7 @@ concurrency: buildpack_update
 
 jobs:
   update-buildpack-toml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Update buildpack.toml
     steps:
 

--- a/language-family/.github/workflows/update-github-config.yml
+++ b/language-family/.github/workflows/update-github-config.yml
@@ -10,7 +10,7 @@ concurrency: github_config_update
 jobs:
   build:
     name: Create PR to update shared files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout

--- a/stack/.github/workflows/approve-bot-pr.yml
+++ b/stack/.github/workflows/approve-bot-pr.yml
@@ -10,7 +10,7 @@ jobs:
   download:
     name: Download PR Artifact
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr-author: ${{ steps.pr-data.outputs.author }}
       pr-number: ${{ steps.pr-data.outputs.number }}
@@ -32,7 +32,7 @@ jobs:
     name: Approve Bot PRs
     needs: download
     if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Commit Verification
       id: unverified-commits

--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   poll_usns:
     name: Poll USNs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       usns: ${{ steps.usns.outputs.usns }}
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   stack_files_changed:
     name: Determine If Stack Files Changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: poll_usns
     if: ${{ ! ( needs.poll_usns.outputs.usns == '[]' && github.event_name == 'schedule' ) }}
     outputs:
@@ -124,7 +124,7 @@ jobs:
 
   run_if_stack_files_changed:
     name: Run If Stack Files Changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [stack_files_changed]
     if: ${{ needs.stack_files_changed.outputs.stack_files_changed == 'true' }}
     steps:
@@ -136,7 +136,7 @@ jobs:
     name: Create Stack
     needs: poll_usns
     if: ${{ ! ( needs.poll_usns.outputs.usns == '[]' && github.event_name == 'schedule' ) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -197,7 +197,7 @@ jobs:
       run_removed_with_force: ${{ steps.run_diff.outputs.removed }}
       removed_with_force: ${{ steps.removed_with_force.outputs.packages_removed }}
     needs: [ create_stack ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Download Build Receipt
       uses: actions/download-artifact@v3
@@ -289,7 +289,7 @@ jobs:
   run_if_packages_removed_with_force:
     name: Run If Packages Removed With Force
     needs: [ diff ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ needs.diff.outputs.removed_with_force == 'true' }}
     steps:
     - name: Run if packages removed with force
@@ -299,7 +299,7 @@ jobs:
   packages_changed:
     name: Determine If Packages Changed
     needs: [ diff ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       packages_changed: ${{ steps.compare.outputs.packages_changed }}
     steps:
@@ -338,7 +338,7 @@ jobs:
 
   run_if_packages_changed:
     name: Run If Packages Changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [packages_changed]
     if: ${{ needs.packages_changed.outputs.packages_changed == 'true' }}
     steps:
@@ -349,7 +349,7 @@ jobs:
   test:
     name: Acceptance Test
     needs: [ create_stack ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -380,7 +380,7 @@ jobs:
 
   force_release_creation:
     name: Force Release Creation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{github.event.inputs.force == 'true'}}
     steps:
     - name: Signal force release creation
@@ -389,7 +389,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [poll_usns, create_stack, diff, run_if_stack_files_changed, run_if_packages_changed, run_if_packages_removed_with_force, test, force_release_creation ]
     if: ${{ always() && needs.diff.result == 'success' && needs.test.result == 'success' && (needs.run_if_packages_changed.result == 'success' || needs.run_if_stack_files_changed.result == 'success' || needs.force_release_creation.result == 'success' ) }}
     steps:
@@ -543,7 +543,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [poll_usns, create_stack, diff, test, release, packages_changed, stack_files_changed]
     if: ${{ always() && needs.poll_usns.result == 'failure' || needs.create_stack.result == 'failure' || needs.diff.result == 'failure' || needs.test.result == 'failure' || needs.release.result == 'failure' || needs.packages_changed.result == 'failure' || needs.stack_files_changed.result == 'failure' }}
     steps:

--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Parse Event
@@ -90,7 +90,7 @@ jobs:
 
   failure:
     name: Alert on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [push]
     if: ${{ always() && needs.push.result == 'failure' }}
     steps:

--- a/stack/.github/workflows/synchronize-labels.yml
+++ b/stack/.github/workflows/synchronize-labels.yml
@@ -9,7 +9,7 @@ jobs:
     synchronize:
         name: Synchronize Labels
         runs-on:
-            - ubuntu-latest
+            - ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Acceptance Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -34,7 +34,7 @@ jobs:
 
   upload:
     name: Upload Workflow Event Payload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/stack/.github/workflows/update-github-config.yml
+++ b/stack/.github/workflows/update-github-config.yml
@@ -10,7 +10,7 @@ concurrency: github_config_update
 jobs:
   build:
     name: Create PR to update shared files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout


### PR DESCRIPTION
## Summary

This PR ensures we run all workflows on Ubuntu 22.04 (Jammy). Currently we are running workflows on `ubuntu-latest` which actually maps to Ubuntu 20.04 (Focal) according to the [official README](https://github.com/actions/runner-images#available-images).

## Use Cases

The changes introduced to `curl` in #550 require a newer version of `curl`, and the easiest way to fix that is to use a more recent version of Ubuntu which has that version.

Also, there is no reason to be running our workflows on an older version of Ubuntu.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
