### PR TITLE
Fix bug in issue-opening action logic

### DIFF
--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -58,7 +58,7 @@ runs:
 
         # if there is already an issue with the same title, then comment
         # the failure on that issue, rather than opening a new issue.
-        issue_number=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --search "${{ inputs.issue_title }}" --json number --jq .[0].number)
+        issue_number=$(gh issue list --repo "${{ inputs.repo }}" --state all --label "${{ inputs.label }}" --search "${{ inputs.issue_title }} in:title" --json number --jq .[0].number)
 
         if [ -n "${issue_number}" ]; then
           gh issue reopen "${issue_number}" \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

We encountered a scenario in the dep-server in which the wrong issue is re-opened for workflow failures: https://github.com/paketo-buildpacks/dep-server/issues/196 (scroll to the bottom).

This occurs because the `gh` CLI issue search term was missing the `in:title` part in the `--search` argument, causing the wrong title to be selected on in the search query.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Fix issue-opening action failures in dep-server

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
