### PR TITLE
Ensure that PR checks fail if integration test matrix fails.

### DIFF
--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -63,12 +63,19 @@ jobs:
 
   roundup:
     name: Integration Tests
+    if: ${{ always() }}
     runs-on: ubuntu-22.04
     needs: integration
     steps:
     - run: |
-        echo "Integration tests passed against all builders"
-        exit 0
+        result="${{ needs.integration.result }}"
+        if [[ $result == "success" ]]; then
+          echo "Integration tests passed against all builders"
+          exit 0
+        else
+          echo "Integration tests failed on one or more builders"
+          exit 1
+        fi
 
   upload:
     name: Upload Workflow Event Payload

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -52,12 +52,19 @@ jobs:
 
   roundup:
     name: Integration Tests
+    if: ${{ always() }}
     runs-on: ubuntu-22.04
     needs: integration
     steps:
     - run: |
-        echo "Integration tests passed against all builders"
-        exit 0
+        result="${{ needs.integration.result }}"
+        if [[ $result == "success" ]]; then
+          echo "Integration tests passed against all builders"
+          exit 0
+        else
+          echo "Integration tests failed on one or more builders"
+          exit 1
+        fi
 
   upload:
     name: Upload Workflow Event Payload


### PR DESCRIPTION
## Summary

This PR fixes the logic for the dynamic matrix `roundup` job for the integration tests.

* Currently if one or more of the matrix jobs fails, the `roundup` job never runs and is considered `skipped`.
    * You can validate that the job is considered skipped by looking in the UI for a failed build e.g. [here](https://github.com/pivotal-cf/tanzu-nodejs/runs/8229792500?check_suite_focus=true).
* If a job is considered `skipped`, then any PR checks that rely on it succeeding will actually pass. According to the [official Github actions documentation](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution):
    > Note: A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.
* To fix this we do a couple of things:
    * Set the `roundup` job to run with `if: ${{ always() }}` so that it will run regardless of the status of the jobs it depends on (i.e. `integration`).
    * Explicitly pass or fail the `roundup` job based on the results of the matrix job.
* You can see a minimal reproducible example of the current behavior [here](https://github.com/robdimsdale/scratch/pull/1).
<img width="906" alt="Screen Shot 2022-09-07 at 1 58 11 PM" src="https://user-images.githubusercontent.com/7230694/188946809-65333a89-a696-4565-a617-0e53d091ad9c.png">

* You can see a minimal reproducible example of the new behavior [here](https://github.com/robdimsdale/scratch/pull/2).
<img width="915" alt="Screen Shot 2022-09-07 at 1 58 33 PM" src="https://user-images.githubusercontent.com/7230694/188946876-65569e12-8c55-44bb-bcd1-cb6116250bd3.png">

* Notice that in the first case the `Integration Tests` job is skipped and the PR is mergable, but in the second case the `Integration Tests` job ran, failed, and the PR is not mergable - even with auto-merge enabled.
* For completeness, I also validated that the PR is mergable in the case where all the matrix tests pass [here](https://github.com/robdimsdale/scratch/pull/3).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
