### PR TITLE
Fix typos in printing of stack package diffs.

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -312,7 +312,7 @@ jobs:
 
         # shellcheck disable=SC2153
         build_modified=$(jq '. | length' <<< "${BUILD_MODIFIED}")
-        echo "Build packages modified: ${build_added}"
+        echo "Build packages modified: ${build_modified}"
 
         # shellcheck disable=SC2153
         run_added=$(jq '. | length' <<< "${RUN_ADDED}")
@@ -320,7 +320,7 @@ jobs:
 
         # shellcheck disable=SC2153
         run_modified=$(jq '. | length' <<< "${RUN_MODIFIED}")
-        echo "Run packages added: ${run_added}"
+        echo "Run packages modified: ${run_modified}"
 
         if [ "${build_added}" -eq 0 ] && [ "${build_modified}" -eq 0 ] && [ "${run_added}" -eq 0 ] && [ "${run_modified}" -eq 0 ]; then
           echo "No packages changed."


### PR DESCRIPTION
## Summary
This PR fixes a couple of typos in the printing of the stack package diff. There is no functional change to the workflow - just fixing incorrect log/print statements.

Example current output (e.g. this [run](https://github.com/pivotal-cf/tanzu-jammy-tiny-stack/actions/runs/3064124951/jobs/4946989135)):

```
Build packages added: 0
Build packages modified: 0
Run packages added: 0
Run packages added: 0
Packages changed.
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
