### PR TITLE
Release note action: do not fail out if no release is found

### DIFF
--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -74,8 +74,6 @@ function main() {
   local version
   version="$(
     curl "https://api.github.com/repos/${repo}/releases/latest" \
-      --fail-with-body \
-      --show-error \
       --header "Authorization: token ${token}" \
       --location \
       --silent \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Since we introduced the `--fail-with-body` flag to our actions, the release note action fails on the first release of a buildpack (as seen [here](https://github.com/paketo-buildpacks/dotnet-core-aspnet-runtime/actions/runs/3137370007)) due to no previous release being found. This specific step should not fail out if no release is found, as the release note code is already written to deal with that happening.

cc @paketo-buildpacks/dotnet-core-maintainers 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
