### PR TITLE
Use create stack action in create-release and test-pull-request.

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -142,15 +142,8 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create stack
-      run: |
-        # If the repository name contains 'full' then we create the stack with
-        # the --unbuffered flag to avoid hitting memory limits in github
-        # workers
-        if [[ ${{ github.repository }} == *-"full"-* ]]; then
-          ./scripts/create.sh --unbuffered
-        else
-          ./scripts/create.sh
-        fi
+      id: create-stack
+      uses: paketo-buildpacks/github-config/actions/stack/create-stack@main
 
     - name: Generate Package Receipts
       id: receipts

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -19,15 +19,8 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create stack
-      run: |
-        # If the repository name contains 'full' then we create the stack with
-        # the --unbuffered flag to avoid hitting memory limits in github
-        # workers
-        if [[ ${{ github.repository }} == *-"full"-* ]]; then
-          ./scripts/create.sh --unbuffered
-        else
-          ./scripts/create.sh
-        fi
+      id: create-stack
+      uses: paketo-buildpacks/github-config/actions/stack/create-stack@main
 
     - name: Run Acceptance Tests
       run: ./scripts/test.sh


### PR DESCRIPTION
## Summary

This PR leverages the `create-stack` action added in #560 instead of duplicating the logic for creating stacks.

## Use Cases

This PR reduces duplication and allows the workflow to leverage features that are encapsulated within the action like support for secrets.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
