### PR TITLE
Add manual trigger to label syncing on repos

### DIFF
--- a/builder/.github/workflows/synchronize-labels.yml
+++ b/builder/.github/workflows/synchronize-labels.yml
@@ -5,6 +5,7 @@ name: Synchronize Labels
             - main
         paths:
             - .github/labels.yml
+    workflow_dispatch: {}
 jobs:
     synchronize:
         name: Synchronize Labels

--- a/implementation/.github/workflows/synchronize-labels.yml
+++ b/implementation/.github/workflows/synchronize-labels.yml
@@ -5,6 +5,7 @@ name: Synchronize Labels
             - main
         paths:
             - .github/labels.yml
+    workflow_dispatch: {}
 jobs:
     synchronize:
         name: Synchronize Labels

--- a/language-family/.github/workflows/synchronize-labels.yml
+++ b/language-family/.github/workflows/synchronize-labels.yml
@@ -5,6 +5,7 @@ name: Synchronize Labels
             - main
         paths:
             - .github/labels.yml
+    workflow_dispatch: {}
 jobs:
     synchronize:
         name: Synchronize Labels

--- a/library/.github/workflows/synchronize-labels.yml
+++ b/library/.github/workflows/synchronize-labels.yml
@@ -10,12 +10,12 @@ on:
   workflow_dispatch: {}
 
 jobs:
-    synchronize:
-        name: Synchronize Labels
-        runs-on:
-            - ubuntu-22.04
-        steps:
-            - uses: actions/checkout@v3
-            - uses: micnncim/action-label-syncer@v1
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
+  synchronize:
+    name: Synchronize Labels
+    runs-on:
+      - ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/library/.github/workflows/synchronize-labels.yml
+++ b/library/.github/workflows/synchronize-labels.yml
@@ -7,14 +7,15 @@ on:
       - v*
     paths:
       - .github/labels.yml
+  workflow_dispatch: {}
 
 jobs:
-  synchronize:
-    name: Synchronize Labels
-    runs-on:
-      - ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: micnncim/action-label-syncer@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+    synchronize:
+        name: Synchronize Labels
+        runs-on:
+            - ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v3
+            - uses: micnncim/action-label-syncer@v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/stack/.github/workflows/synchronize-labels.yml
+++ b/stack/.github/workflows/synchronize-labels.yml
@@ -5,6 +5,7 @@ name: Synchronize Labels
             - main
         paths:
             - .github/labels.yml
+    workflow_dispatch: {}
 jobs:
     synchronize:
         name: Synchronize Labels


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Sometimes, a repo's labels drift from the desired sync'd values. This lets maintainers push a button to bring things back in line.

Also updates the `library` version of the workflow to be more similar to the other repo types' workflows.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
