### PR TITLE
Fail fast with helpful error message when trying to create stack with old version of bash

### DIFF
--- a/stack/scripts/create.sh
+++ b/stack/scripts/create.sh
@@ -15,6 +15,10 @@ source "${PROG_DIR}/.util/tools.sh"
 # shellcheck source=SCRIPTDIR/.util/print.sh
 source "${PROG_DIR}/.util/print.sh"
 
+if [[ $BASH_VERSINFO -lt 4 ]]; then
+  util::print::error "Before running this script please update Bash to v4 or higher (e.g. on OSX: \$ brew install bash)"
+fi
+
 function main() {
   local unbuffered secrets
 


### PR DESCRIPTION
## Summary

This PR ensures that the create-stack script fails fast with a helpful error when the version of bash is less than v4.

## Background

Bash v4 was released in 2011, and so all modern linux operating systems run with at least this version of bash. Additionally, homebrew installs at least this version of bash.

The most likely situations where a user will encounter this is running on OSX with the default version of bash (which is still v3). Therefore it is reasonable to require these users to install a newer bash.

## Use Cases

Resolves #576 - this provides useful, actionable, feedback to users if their bash is too old.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
