### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -27,7 +27,7 @@ runs:
           --silent \
         | jq -r -S .tag_name
       )"
-      echo "::set-output name=version::${version#v}"
+      echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   - name: Install Jam
     shell: bash

--- a/actions/buildpack/update/action.yml
+++ b/actions/buildpack/update/action.yml
@@ -25,7 +25,7 @@ runs:
       #!/usr/bin/env bash
       set -eu
       version=$(jq -r .jam "scripts/.util/tools.json")
-      echo "::set-output name=version::${version#v}"
+      echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   - name: Install Jam
     shell: bash

--- a/actions/dependency/update-from-metadata/action.yml
+++ b/actions/dependency/update-from-metadata/action.yml
@@ -27,7 +27,7 @@ runs:
       #!/usr/bin/env bash
       set -eu
       version=$(jq -r .jam "scripts/.util/tools.json")
-      echo "::set-output name=version::${version#v}"
+      echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   - name: Install Jam
     shell: bash
@@ -55,5 +55,5 @@ runs:
           --metadata-file "${{ inputs.metadata_file_path }}" \
       )"
       versions="$(echo ${versions} | cut -d'[' -f2- | cut -d']' -f-1 | sed 's/ /, /g')"
-      echo "::set-output name=new_versions::${versions}"
+      echo "new_versions=${versions}" >> "$GITHUB_OUTPUT"
       echo "Added versions ${versions}"

--- a/actions/dependency/update/action.yml
+++ b/actions/dependency/update/action.yml
@@ -19,7 +19,7 @@ runs:
       #!/usr/bin/env bash
       set -eu
       version=$(jq -r .jam "scripts/.util/tools.json")
-      echo "::set-output name=version::${version#v}"
+      echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   - name: Install Jam
     shell: bash
@@ -48,4 +48,4 @@ runs:
           --buildpack-file "${PWD}/buildpack.toml"
       )"
       versions="$(echo ${versions} | cut -d'[' -f2- | cut -d']' -f-1 | sed 's/ /, /g')"
-      echo "::set-output name=new_versions::${versions}"
+      echo "new_versions=${versions}" >> "$GITHUB_OUTPUT"

--- a/actions/dependency/upload-to-s3/action.yml
+++ b/actions/dependency/upload-to-s3/action.yml
@@ -34,4 +34,4 @@ runs:
 
         # Access at https://artifacts.paketo.io/<dependency>/artifact.tgz
         uri="https://artifacts.paketo.io/${{ inputs.dependency-name }}/${filename}"
-        echo "::set-output name=uri::${uri}"
+        echo "uri=${uri}" >> "$GITHUB_OUTPUT"

--- a/actions/pull-request/auto-semver-label/action.yml
+++ b/actions/pull-request/auto-semver-label/action.yml
@@ -23,10 +23,10 @@ runs:
       retVal=$?
       if [ $retVal -ne 0 ]; then
         echo "No Github credentials provided."
-        echo "::set-output name=status::false"
+        echo "status=false" >> "$GITHUB_OUTPUT"
         exit 0
       fi
-        echo "::set-output name=status::true"
+        echo "status=true" >> "$GITHUB_OUTPUT"
   - name: Check For Auto-labelable Changes
     id: changes
     shell: bash

--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -39,7 +39,7 @@ function main() {
 
   if [[ "${author}" == "dependabot[bot]" ]]; then
     echo "PR author is dependabot. Labeling as patch."
-    echo "::set-output name=label::patch"
+    echo "label=patch" >> "$GITHUB_OUTPUT"
     exit 0
   fi
 
@@ -48,7 +48,7 @@ function main() {
   retVal=$?
   if [ $retVal -ne 0 ]; then
     echo "No Github credentials provided. Skipping labeling."
-    echo "::set-output name=label::"
+    echo "label=" >> "$GITHUB_OUTPUT"
     exit 0
   fi
   set -e
@@ -76,13 +76,13 @@ function main() {
 
     if [ "${safe}" -eq "0" ]; then
       echo "Files changed that aren't on the patch allowlist"
-      echo "::set-output name=label::"
+      echo "label=" >> "$GITHUB_OUTPUT"
       exit 0
     fi
   done < <(gh api /repos/"${repo}"/pulls/"${number}"/files --jq '.[].filename')
 
   echo "All changes are patches."
-  echo "::set-output name=label::patch"
+  echo "label=patch" >> "$GITHUB_OUTPUT"
 }
 
 main "${@:-}"

--- a/actions/pull-request/check-human-commits/entrypoint
+++ b/actions/pull-request/check-human-commits/entrypoint
@@ -38,10 +38,10 @@ function main() {
   done
 
   if rules::has_human_commits "${token}" "${repo}" "${number}" "${botsString}"; then
-    echo "::set-output name=human_commits::true"
+    echo "human_commits=true" >> "$GITHUB_OUTPUT"
     exit 0
   fi
-    echo "::set-output name=human_commits::false"
+    echo "human_commits=false" >> "$GITHUB_OUTPUT"
 }
 
 function rules::has_human_commits() {

--- a/actions/pull-request/check-unverified-commits/entrypoint
+++ b/actions/pull-request/check-unverified-commits/entrypoint
@@ -32,10 +32,10 @@ function main() {
   done
 
   if rules::has_unverified_commits "${token}" "${repo}" "${number}" ; then
-    echo "::set-output name=unverified_commits::true"
+    echo "unverified_commits=true" >> "$GITHUB_OUTPUT"
     exit 0
   fi
-  echo "::set-output name=unverified_commits::false"
+  echo "unverified_commits=false" >> "$GITHUB_OUTPUT"
 }
 
 function rules::has_unverified_commits() {

--- a/actions/pull-request/create-commit/entrypoint
+++ b/actions/pull-request/create-commit/entrypoint
@@ -65,7 +65,7 @@ function main() {
     git add --all "${pathspec}"
     git commit --message "${message}"
 
-    echo "::set-output name=commit_sha::$(git rev-parse HEAD)"
+    echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
     exit 0
   fi
 }

--- a/actions/release/find-and-download-asset/action.yml
+++ b/actions/release/find-and-download-asset/action.yml
@@ -57,4 +57,4 @@ runs:
       if: ${{ steps.find.outputs.url != '' }}
       shell: bash
       run: |
-        printf "::set-output name=output_path::%s\n" "${{ inputs.output_path }}"
+        printf "output_path=%s\n" "${{ inputs.output_path }}" >> "$GITHUB_OUTPUT"

--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -69,7 +69,7 @@ function find_asset() {
   fi
   echo "Asset URL is: " "${url}"
 
-  printf "::set-output name=url::%s\n" "${url}"
+  printf "url=%s\n" "${url}" >> "$GITHUB_OUTPUT"
 }
 
 main "${@:-}"

--- a/actions/release/notes/Dockerfile
+++ b/actions/release/notes/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add \
     bash \
     curl \
     jq \
+    uuidgen \
   && rm -rf /var/cache/apk/*
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2

--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -119,14 +119,9 @@ function main() {
     fi
   fi
 
-  # Convert multiline output to single line output as GitHub "set-output" does
-  # not support multiline strings:
-  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372#M3322
-  content="${content//'%'/'%25'}"
-  content="${content//$'\n'/'%0A'}"
-  content="${content//$'\r'/'%0D'}"
 
-  echo "::set-output name=release_body::${content}"
+  delimiter="$(uuidgen)"
+  printf "release_body<<%s\n%s\n%s\n" "${delimiter}" "${content}" "${delimiter}" >> "$GITHUB_OUTPUT" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 }
 
 main "${@:-}"

--- a/actions/release/reset-draft/entrypoint/main.go
+++ b/actions/release/reset-draft/entrypoint/main.go
@@ -93,7 +93,17 @@ func main() {
 		fail(fmt.Errorf("unexpected response from delete draft release request: %s", dump))
 	}
 
-	fmt.Printf("::set-output name=current_version::%s\n", releases[0].TagName)
+	outputFileName, ok := os.LookupEnv("GITHUB_OUTPUT")
+	if !ok {
+		fail(errors.New("GITHUB_OUTPUT is not set, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter"))
+	}
+	file, err := os.OpenFile(outputFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		fail(err)
+	}
+	defer file.Close()
+	fmt.Fprintf(file, "current_version=%s\n", releases[0].TagName)
+
 	fmt.Println("Success!")
 }
 

--- a/actions/stack/diff-package-receipts/entrypoint/main.go
+++ b/actions/stack/diff-package-receipts/entrypoint/main.go
@@ -142,9 +142,18 @@ func main() {
 		)
 	}
 
-	fmt.Printf("::set-output name=added::%s\n", string(addedJSON))
-	fmt.Printf("::set-output name=removed::%s\n", string(removedJSON))
-	fmt.Printf("::set-output name=modified::%s\n", string(modifiedJSON))
+	outputFileName, ok := os.LookupEnv("GITHUB_OUTPUT")
+	if !ok {
+		log.Fatal("GITHUB_OUTPUT is not set, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter")
+	}
+	file, err := os.OpenFile(outputFileName, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+	fmt.Fprintf(file, "added=%s\n", string(addedJSON))
+	fmt.Fprintf(file, "removed=%s\n", string(removedJSON))
+	fmt.Fprintf(file, "modified=%s\n", string(modifiedJSON))
 }
 
 func parsePackagesFromFile(path string) (map[string]CycloneDXComponent, error) {

--- a/actions/stack/generate-package-list/action.yml
+++ b/actions/stack/generate-package-list/action.yml
@@ -24,4 +24,4 @@ runs:
       packages=$(jq  '.components[] |  .name' "${{ inputs.build_receipt }}" "${{ inputs.run_receipt }}" \
         | jq --null-input --compact-output '[inputs]')
 
-      printf "::set-output name=packages::%s\n" "${packages}"
+      printf "packages=%s\n" "${packages}" >> "$GITHUB_OUTPUT"

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -126,7 +126,16 @@ func main() {
 	}
 
 	fmt.Println("Output: ", string(output))
-	fmt.Printf("::set-output name=usns::%s\n", string(output))
+	outputFileName, ok := os.LookupEnv("GITHUB_OUTPUT")
+	if !ok {
+		log.Fatal("GITHUB_OUTPUT is not set, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter")
+	}
+	file, err := os.OpenFile(outputFileName, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+	fmt.Fprintf(file, "usns=%s\n", string(output))
 
 	if config.Output != "" {
 		path, err := filepath.Abs(config.Output)

--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -51,6 +51,6 @@ main() {
     tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
   fi
 
-  echo "::set-output name=tag::${tag#v}"
+  echo "tag=${tag#v}" >> "$GITHUB_OUTPUT"
 }
 main "${@:-}"

--- a/actions/tools/latest/entrypoint
+++ b/actions/tools/latest/entrypoint
@@ -46,7 +46,7 @@ function main() {
     | jq -r -S .tag_name
   )"
 
-  echo "::set-output name=version::${version}"
+  echo "version=${version}" >> "$GITHUB_OUTPUT"
 }
 
 main "${@:-}"

--- a/builder/.github/workflows/approve-bot-pr.yml
+++ b/builder/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(jq -r '.pull_request.user.login' event.json)"
-        echo "::set-output name=number::$(jq -r '.pull_request.number' event.json)"
+        echo "author=$(jq -r '.pull_request.user.login' event.json)" >> "$GITHUB_OUTPUT"
+        echo "number=$(jq -r '.pull_request.number' event.json)" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
       id: pack-version
       run: |
         version=$(jq -r .pack "scripts/.util/tools.json")
-        echo "::set-output name=version::${version#v}"
+        echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
     - name: Install Global Pack
       uses: buildpacks/github-actions/setup-pack@main
@@ -46,7 +46,7 @@ jobs:
           | grep -v 'Warning' \
           | sed -e '/./,$!d' \
           | awk -F, '{printf "%s\\n", $0}')"
-        echo "::set-output name=body::${notes}"
+        echo "body=${notes}" >> "$GITHUB_OUTPUT"
 
   release:
     name: Release
@@ -63,9 +63,9 @@ jobs:
       run: |
         if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder.toml)" ]
         then
-          echo "::set-output name=builder_changes::false"
+          echo "builder_changes=false" >> "$GITHUB_OUTPUT"
         else
-          echo "::set-output name=builder_changes::true"
+          echo "builder_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Publish Release
@@ -112,4 +112,4 @@ jobs:
         issue_body: |
           Create Release workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
         comment_body: |
-           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/push-image.yml
+++ b/builder/.github/workflows/push-image.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Parse Event
       id: event
       run: |
-        echo "::set-output name=tag::$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
+        echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
       id: pack-version
       run: |
         version=$(jq -r .pack "scripts/.util/tools.json")
-        echo "::set-output name=version::${version#v}"
+        echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
     - name: Install Global Pack
       uses: buildpacks/github-actions/setup-pack@main

--- a/implementation/.github/workflows/approve-bot-pr.yml
+++ b/implementation/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+        echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> "$GITHUB_OUTPUT"
+        echo "number=$(cat event.json | jq -r '.pull_request.number')" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -35,7 +35,7 @@ jobs:
         source "${{ github.workspace }}/scripts/.util/builders.sh"
         builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
         printf "Output: %s\n" "${builders}"
-        printf "::set-output name=builders::%s\n" "${builders}"
+        printf "builders=%s\n" "${builders}" >> "$GITHUB_OUTPUT"
 
   integration:
     name: Integration Tests
@@ -91,7 +91,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
     - name: Package
       run: ./scripts/package.sh --version "${{ steps.tag.outputs.tag }}"
     - name: Create Release Notes

--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -17,10 +17,10 @@ jobs:
         FULL_VERSION="$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
         MINOR_VERSION="$(echo "${FULL_VERSION}" | awk -F '.' '{print $1 "." $2 }')"
         MAJOR_VERSION="$(echo "${FULL_VERSION}" | awk -F '.' '{print $1 }')"
-        echo "::set-output name=tag_full::${FULL_VERSION}"
-        echo "::set-output name=tag_minor::${MINOR_VERSION}"
-        echo "::set-output name=tag_major::${MAJOR_VERSION}"
-        echo "::set-output name=download_url::$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")"
+        echo "tag_full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "tag_minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "tag_major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "download_url=$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
     - name: Download
       id: download
@@ -63,8 +63,8 @@ jobs:
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_minor }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_major }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:latest"
-        echo "::set-output name=image::${IMAGE}"
-        echo "::set-output name=digest::$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)"
+        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "digest=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)" >> "$GITHUB_OUTPUT"
 
     - name: Register with CNB Registry
       uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:main

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
 
         builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
         printf "Output: %s\n" "${builders}"
-        printf "::set-output name=builders::%s\n" "${builders}"
+        printf "builders=%s\n" "${builders}" >> "$GITHUB_OUTPUT"
 
   integration:
     name: Integration Tests with Builders

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Select Go Version
         id: select-go-version
-        run: echo "::set-output name=go-version::>=1.18.0"
+        run: echo "go-version=>=1.18.0" >> "$GITHUB_OUTPUT"
 
   retrieve:
     name: Retrieve New Versions and Generate Metadata
@@ -58,20 +58,14 @@ jobs:
           compilation=$(echo $content | jq -r 'map(select(.checksum == null and .uri == null))'?)
           complength=$(echo $compilation | jq -r '. | length')
 
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
+          delimiter="$(uuidgen)"
+          echo "metadata-filepath=${OUTPUT}" >> "$GITHUB_OUTPUT"
+          printf "metadata-json<<%s\n%s\n%s\n" "${delimiter}" "${content}" "${delimiter}" >> "$GITHUB_OUTPUT" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          echo "length=$length" >> "$GITHUB_OUTPUT"
+          printf "compilation-json<<%s\n%s\n%s\n" "${delimiter}" "${compilation}" "${delimiter}" >> "$GITHUB_OUTPUT" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          echo "compilation-length=$complength" >> "$GITHUB_OUTPUT"
 
-          compilation="${compilation//'%'/'%25'}"
-          compilation="${compilation//$'\n'/'%0A'}"
-          compilation="${compilation//$'\r'/'%0D'}"
-
-          echo "::set-output name=metadata-filepath::${OUTPUT}"
-          echo "::set-output name=metadata-json::$content"
-          echo "::set-output name=id::$id"
-          echo "::set-output name=length::$length"
-          echo "::set-output name=compilation-json::$compilation"
-          echo "::set-output name=compilation-length::$complength"
 
       - name: Upload `${{ steps.retrieve.outputs.metadata-filepath }}`
         uses: actions/upload-artifact@v3
@@ -97,7 +91,7 @@ jobs:
         run: |
           if test -d "dependency/actions/compile"; then
             echo "Compilation action provided"
-            echo "::set-output name=should-compile::true"
+            echo "should-compile=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Has Testing Action?
@@ -105,7 +99,7 @@ jobs:
         run: |
           if test -d "dependency/test"; then
             echo "Testing file provided"
-            echo "::set-output name=should-test::true"
+            echo "should-test=true" >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -130,7 +124,7 @@ jobs:
       - name: Make Temporary Artifact Directory
         id: make-outputdir
         run: |
-          echo "::set-output name=outputdir::$(mktemp -d)"
+          echo "outputdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       # Download the tarball for testing if:
       #   (1) dependency testing code is present in the buildpack directory
@@ -172,7 +166,7 @@ jobs:
       - name: Make Temporary Artifact Directory
         id: make-outputdir
         run: |
-          echo "::set-output name=outputdir::$(mktemp -d)"
+          echo "outputdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       # Compile if all of the following conditions are met:
       #   (1) compilation Github Action presetn in the buildpack directory
@@ -232,8 +226,8 @@ jobs:
       - name: Get artifact file name
         id: get-file-names
         run: |
-          echo "::set-output name=artifact-file::$(basename ./*.tgz)"
-          echo "::set-output name=checksum-file::$(basename ./*.tgz.checksum)"
+          echo "artifact-file=$(basename ./*.tgz)" >> "$GITHUB_OUTPUT"
+          echo "checksum-file=$(basename ./*.tgz.checksum)" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -252,7 +246,7 @@ jobs:
 
       - name: Get Checksum
         id: get-checksum
-        run: echo "::set-output name=checksum::$(cat ${{ steps.get-file-names.outputs.checksum-file }})"
+        run: echo "checksum=$(cat ${{ steps.get-file-names.outputs.checksum-file }})" >> "$GITHUB_OUTPUT"
 
       - name: Download metadata.json
         uses: actions/download-artifact@v3
@@ -301,7 +295,7 @@ jobs:
       - name: Make Temporary Artifact Directory
         id: make-outputdir
         run: |
-          echo "::set-output name=outputdir::$(mktemp -d)"
+          echo "outputdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download metadata.json
         uses: actions/download-artifact@v3

--- a/implementation/.github/workflows/update-dependencies.yml
+++ b/implementation/.github/workflows/update-dependencies.yml
@@ -44,7 +44,7 @@ jobs:
       id: title
       if: ${{ steps.update.outputs.new-versions != '' }}
       run: |
-        echo "::set-output name=include_versions:: with new dependency versions: ${{ steps.update.outputs.new-versions }}"
+        echo "include_versions= with new dependency versions: ${{ steps.update.outputs.new-versions }}" >> "$GITHUB_OUTPUT"
 
     - name: Open Pull Request
       if: ${{ steps.commit.outputs.commit_sha != '' }}

--- a/language-family/.github/workflows/approve-bot-pr.yml
+++ b/language-family/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+        echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> "$GITHUB_OUTPUT"
+        echo "number=$(cat event.json | jq -r '.pull_request.number')" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/language-family/.github/workflows/create-draft-release.yml
+++ b/language-family/.github/workflows/create-draft-release.yml
@@ -30,7 +30,7 @@ jobs:
 
         builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
         printf "Output: %s\n" "${builders}"
-        printf "::set-output name=builders::%s\n" "${builders}"
+        printf "builders=%s\n" "${builders}" >> "$GITHUB_OUTPUT"
   integration:
     name: Integration Tests
     runs-on: ubuntu-22.04
@@ -79,7 +79,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
     - name: Package
       run: ./scripts/package.sh --version "${{ steps.tag.outputs.tag }}"
     - name: Create Release Notes

--- a/language-family/.github/workflows/push-buildpackage.yml
+++ b/language-family/.github/workflows/push-buildpackage.yml
@@ -17,10 +17,10 @@ jobs:
         FULL_VERSION="$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
         MINOR_VERSION="$(echo "${FULL_VERSION}" | awk -F '.' '{print $1 "." $2 }')"
         MAJOR_VERSION="$(echo "${FULL_VERSION}" | awk -F '.' '{print $1 }')"
-        echo "::set-output name=tag_full::${FULL_VERSION}"
-        echo "::set-output name=tag_minor::${MINOR_VERSION}"
-        echo "::set-output name=tag_major::${MAJOR_VERSION}"
-        echo "::set-output name=download_url::$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")"
+        echo "tag_full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "tag_minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "tag_major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "download_url=$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
     - name: Download
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
@@ -63,8 +63,8 @@ jobs:
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_minor }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_major }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:latest"
-        echo "::set-output name=image::${IMAGE}"
-        echo "::set-output name=digest::$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)"
+        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+        echo "digest=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)" >> "$GITHUB_OUTPUT"
 
     - name: Register with CNB Registry
       uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:main

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
 
         builders="$(util::builders::list "${{ github.workspace }}/integration.json")"
         printf "Output: %s\n" "${builders}"
-        printf "::set-output name=builders::%s\n" "${builders}"
+        printf "builders=%s\n" "${builders}" >> "$GITHUB_OUTPUT"
 
   integration:
     name: Integration Tests with Builders

--- a/library/.github/workflows/approve-bot-pr.yml
+++ b/library/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+        echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> "$GITHUB_OUTPUT"
+        echo "number=$(cat event.json | jq -r '.pull_request.number')" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/library/.github/workflows/create-draft-release.yml
+++ b/library/.github/workflows/create-draft-release.yml
@@ -62,7 +62,7 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:

--- a/stack/.github/workflows/approve-bot-pr.yml
+++ b/stack/.github/workflows/approve-bot-pr.yml
@@ -25,8 +25,8 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - id: pr-data
       run: |
-        echo "::set-output name=author::$(jq -r '.pull_request.user.login' < event.json)"
-        echo "::set-output name=number::$(jq -r '.pull_request.number' < event.json)"
+        echo "author=$(jq -r '.pull_request.user.login' < event.json)" >> "$GITHUB_OUTPUT"
+        echo "number=$(jq -r '.pull_request.number' < event.json)" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Approve Bot PRs

--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -75,7 +75,7 @@ jobs:
       if: ${{ steps.download_patched.outputs.output_path != '' }}
       run: |
         patched=$(jq --compact-output . < "${GITHUB_WORKSPACE}/${{ env.PATCHED_USNS_FILENAME }}")
-        printf "::set-output name=patched::%s\n" "${patched}"
+        printf "patched=%s\n" "${patched}" >> "$GITHUB_OUTPUT"
 
     - name: Get Stack Distribution Name
       id: distro
@@ -84,7 +84,7 @@ jobs:
         # paketo-buildpacks/jammy-tiny-stack --> jammy
         distro="$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-.*$//')"
         echo "Ubuntu distribution: ${distro}"
-        printf "::set-output name=distro::%s\n" "${distro}"
+        printf "distro=%s\n" "${distro}" >> "$GITHUB_OUTPUT"
 
     - name: Get New USNs
       id: usns
@@ -115,11 +115,11 @@ jobs:
         if [ -z "${changed}" ]
         then
           echo "No relevant files changed since previous release."
-          echo "::set-output name=stack_files_changed::false"
+          echo "stack_files_changed=false" >> "$GITHUB_OUTPUT"
         else
           echo "Relevant files have changed since previous release."
           echo "${changed}"
-          echo "::set-output name=stack_files_changed::true"
+          echo "stack_files_changed=true" >> "$GITHUB_OUTPUT"
         fi
 
   run_if_stack_files_changed:
@@ -152,8 +152,8 @@ jobs:
                             --run-archive "${GITHUB_WORKSPACE}/build/run.oci" \
                             --build-receipt ${{ env.BUILD_RECEIPT_FILENAME }} \
                             --run-receipt ${{ env.RUN_RECEIPT_FILENAME }}
-        echo "::set-output name=build_receipt::${{ env.BUILD_RECEIPT_FILENAME }}"
-        echo "::set-output name=run_receipt::${{ env.RUN_RECEIPT_FILENAME }}"
+        echo "build_receipt=${{ env.BUILD_RECEIPT_FILENAME }}" >> "$GITHUB_OUTPUT"
+        echo "run_receipt=${{ env.RUN_RECEIPT_FILENAME }}" >> "$GITHUB_OUTPUT"
 
     - name: Upload run image
       uses: actions/upload-artifact@v3
@@ -208,10 +208,10 @@ jobs:
         gh auth status
         # shellcheck disable=SC2046
         if [ $(gh api "/repos/${{ github.repository }}/releases" | jq -r 'length') -eq 0 ]; then
-          echo "::set-output name=exists::false"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        echo "::set-output name=exists::true"
+        echo "exists=true" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -270,10 +270,10 @@ jobs:
              echo "Packages removed without authorization. Stack cannot be released."
              exit 1
            else
-             echo "::set-output name=packages_removed::true"
+             echo "packages_removed=true" >> "$GITHUB_OUTPUT"
            fi
          else
-           echo "::set-output name=packages_removed::false"
+           echo "packages_removed=false" >> "$GITHUB_OUTPUT"
          fi
       env:
         BUILD_REMOVED: ${{ steps.build_diff.outputs.removed }}
@@ -317,10 +317,10 @@ jobs:
 
         if [ "${build_added}" -eq 0 ] && [ "${build_modified}" -eq 0 ] && [ "${run_added}" -eq 0 ] && [ "${run_modified}" -eq 0 ]; then
           echo "No packages changed."
-          echo "::set-output name=packages_changed::false"
+          echo "packages_changed=false" >> "$GITHUB_OUTPUT"
         else
           echo "Packages changed."
-          echo "::set-output name=packages_changed::true"
+          echo "packages_changed=true" >> "$GITHUB_OUTPUT"
         fi
 
       env:
@@ -434,14 +434,14 @@ jobs:
         if [ -z "${tag}" ]; then
           tag="${{ steps.semver.outputs.tag }}"
         fi
-        echo "::set-output name=tag::${tag}"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
     - name: Write USNs File
       id: write_usns
       if: ${{ needs.poll_usns.outputs.usns != '[]'  }}
       run: |
         jq . <<< "${USNS}" > "${USNS_PATH}"
-        echo "::set-output name=usns::${USNS_PATH}"
+        echo "usns=${USNS_PATH}" >> "$GITHUB_OUTPUT"
       env:
         USNS_PATH: "${{ env.PATCHED_USNS_FILENAME }}"
         USNS: ${{ needs.poll_usns.outputs.usns }}
@@ -453,12 +453,12 @@ jobs:
         # Strip off the org and slash from repo name
         # paketo-buildpacks/repo-name --> repo-name
         repo=$(echo "${full}" | sed 's/^.*\///')
-        echo "::set-output name=github_repo_name::${repo}"
+        echo "github_repo_name=${repo}" >> "$GITHUB_OUTPUT"
 
         # Strip off 'stack' suffix from repo name
         # some-name-stack --> some-name
         registry_repo="${repo//-stack/}"
-        echo "::set-output name=registry_repo_name::${registry_repo}"
+        echo "registry_repo_name=${registry_repo}" >> "$GITHUB_OUTPUT"
 
 
     - name: Create Release Notes
@@ -520,7 +520,7 @@ jobs:
           ]' <<< "${assets}")"
         fi
 
-        printf "::set-output name=assets::%s\n" "${assets}"
+        printf "assets=%s\n" "${assets}" >> "$GITHUB_OUTPUT"
 
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main

--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -14,9 +14,9 @@ jobs:
     - name: Parse Event
       id: event
       run: |
-        echo "::set-output name=tag::$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)"
-        echo "::set-output name=build_download_url::$(jq -r '.release.assets[] | select(.name | endswith("build.oci")) | .url' "${GITHUB_EVENT_PATH}")"
-        echo "::set-output name=run_download_url::$(jq -r '.release.assets[] | select(.name | endswith("run.oci")) | .url' "${GITHUB_EVENT_PATH}")"
+        echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
+        echo "build_download_url=$(jq -r '.release.assets[] | select(.name | endswith("build.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "run_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       run: |
         # Strip off the Github org prefix and 'stack' suffix from repo name
         # paketo-buildpacks/some-name-stack --> some-name
-        echo "::set-output name=name::$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')"
+        echo "name=$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')" >> "$GITHUB_OUTPUT"
 
     - name: Push to DockerHub
       id: push


### PR DESCRIPTION
## Summary

Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

If this PR is to big to review, I can break it down into smaller PRs. 

## Use Cases

Fixes #588

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
