### PR TITLE
Add workflow changes and label for dependency workflow failures

### DIFF
--- a/implementation/.github/labels.yml
+++ b/implementation/.github/labels.yml
@@ -34,3 +34,6 @@
 - name: "failure:push"
   description: An issue filed automatically when a push buildpackage workflow run fails
   color: f00a0a
+- name: "failure:update-dependencies"
+  description: An issue filed automatically when updating buildpack.toml dependencies fails in a workflow
+  color: f00a0a

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -340,3 +340,22 @@ jobs:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           title: "Updates buildpack.toml with ${{ steps.update.outputs.new-versions }}"
           branch: automation/buildpack.toml/update-from-metadata
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [ retrieve, get-compile-and-test, test, compile, update-metadata, assemble ]
+    if: ${{ always() && needs.retrieve.result == 'failure' || needs.get-compile-and-test.result == 'failure' || needs.test.result == 'failure' || needs.compile.result == 'failure' || needs.update-metadata.result == 'failure' || needs.assemble.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-dependencies"
+          comment_if_exists: true
+          issue_title: "Failure: Update Dependencies workflow"
+          issue_body: |
+            Update Dependencies From Metadata workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

#592 
Tested that it gets triggered on a failure [here](https://github.com/paketo-buildpacks/passenger/actions/runs/3364505666), it only failed because the label wasn't available on the repo (it's been added in this PR).

I have high confidence that this will work when the label is available, since we're using an action we already use elsewhere.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
