### PR TITLE
Explictly sort by semver when finding release asset.

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -52,24 +52,51 @@ function find_asset() {
   depth="${2}"
   pattern="${3}"
   strict="${4}"
-  url=$(gh api "repos/${repo}/releases"  \
+
+  release_json=$(gh api "repos/${repo}/releases"  \
     --method GET \
     --paginate \
     | jq -r \
     --arg pattern "${pattern}" \
     --argjson depth "${depth}" \
-    '[ limit($depth; .[] | select( .draft == false )) | .assets | .[] | select(.name | test($pattern)) | .url][0]' )
+    'sort_by(.tag_name | .[1:] | split(".") | map(tonumber))
+    | reverse
+    | map(select(.draft==false))
+    | limit($depth; .)
+    | map(select(.assets | .[] | select(.name | test($pattern))))
+    | .[0]' \
+  )
 
-  if [[ "${url}" == "null" ]]; then
+  if [[ "${release_json}" == "null" ]]; then
       if [[ "${strict}" == "true" ]]; then
-        echo "No matching asset found."
+        echo "Error: no matching asset found for pattern: '${pattern}' on repo: ${repo} and depth: ${depth}."
         exit 1
       fi
     url=""
   fi
-  echo "Asset URL is: " "${url}"
 
-  printf "url=%s\n" "${url}" >> "$GITHUB_OUTPUT"
+  release_version=$(echo "${release_json}" | jq -r '.tag_name')
+
+  assets_json=$(echo "${release_json}" \
+    | jq -r \
+    --arg pattern "${pattern}" \
+    '.assets | map(select(.name|test($pattern)))')
+
+  asset_count=$(echo "${assets_json}" | jq 'length')
+
+  if [[ "${asset_count}" -gt 1 ]]; then
+    echo "Error: expected one asset - found ${asset_count} assets matching pattern: '${pattern}' on ${repo} ${release_version}."
+    echo "${assets_json}" | jq -r '.[] | "- " + (.name)'
+    exit 1
+  fi
+
+  asset_name=$(echo "${assets_json}" | jq -r '.[0].name')
+  asset_url=$(echo "${assets_json}" | jq -r '.[0].url')
+
+  echo "Found asset: '${asset_name}' on ${repo} ${release_version}."
+  echo "Asset URL: ${asset_url}"
+
+  printf "url=%s\n" "${asset_url}" >> "$GITHUB_OUTPUT"
 }
 
 main "${@:-}"


### PR DESCRIPTION
## Summary

GitHub claims to always sort release by semver (descending) but we have seen situations where this is not the case. Therefore we should be explicit about sorting in the order we want when looking for release assets.

I did not find any other situations in this repo where we implicitly relied on the ordering of the `/repo/:full_name/releases` API endpoint.

Additional improvements:
- Improve debuggability by printing release version and asset filename for found asset.
- Exit with error when multiple assets are found.

## Use Cases

Fixes #618 

## Example usage

### Happy path

It is hard to demonstrate the semver ordering, as I have only encountered issues on a private repo. But at least this shows the improved output from the happy-path:

```
❯ GITHUB_OUTPUT=/dev/null GITHUB_TOKEN=<token> ./actions/release/find-asset/entrypoint \
  --repo 'paketo-buildpacks/jammy-full-stack' \
  --pattern 'usns' \
  --strict true \
  --depth '-1'
github.com
  ✓ Logged in to github.com as robdimsdale (GITHUB_TOKEN)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: *******************

Found asset: 'jammy-full-stack-0.0.35-patched-usns.json' on paketo-buildpacks/jammy-full-stack v0.0.35.
Asset URL: https://api.github.com/repos/paketo-buildpacks/jammy-full-stack/releases/assets/83902243
```

### No assets found

This is functionally identical to before - just with improved error output:

```
❯ GITHUB_OUTPUT=/dev/null GITHUB_TOKEN=<token> ./actions/release/find-asset/entrypoint \
  --repo 'paketo-buildpacks/jammy-full-stack' \
  --pattern 'not-a-match' \
  --strict true \
  --depth '-1'
github.com
  ✓ Logged in to github.com as robdimsdale (GITHUB_TOKEN)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: *******************

Error: no matching asset found for pattern: 'not-a-match' on repo: paketo-buildpacks/jammy-full-stack and depth: -1.
```

### Multiple assets found

This wasn't handled before - now we exit with error:

```
❯ GITHUB_OUTPUT=/dev/null GITHUB_TOKEN=<token> ./actions/release/find-asset/entrypoint \
  --repo 'paketo-buildpacks/jammy-full-stack' \
  --pattern 'json' \
  --strict true \
  --depth '-1'
github.com
  ✓ Logged in to github.com as robdimsdale (GITHUB_TOKEN)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: *******************

Error: expected one asset - found 3 assets matching pattern: 'json' on paketo-buildpacks/jammy-full-stack v0.0.35.
- jammy-full-stack-0.0.35-build-receipt.cyclonedx.json
- jammy-full-stack-0.0.35-patched-usns.json
- jammy-full-stack-0.0.35-run-receipt.cyclonedx.json
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
