### PR TITLE
Use pre-built docker images for some actions.

### DIFF
--- a/actions/release/download-asset/action.yml
+++ b/actions/release/download-asset/action.yml
@@ -16,7 +16,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/paketo-buildpacks/actions/release/download-asset:latest'
   args:
   - "--url"
   - ${{ inputs.url }}

--- a/actions/release/find-asset/action.yml
+++ b/actions/release/find-asset/action.yml
@@ -25,7 +25,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/paketo-buildpacks/actions/release/find-asset:latest'
   args:
   - "--repo"
   - "${{ inputs.repo }}"

--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -28,7 +28,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/paketo-buildpacks/actions/stack/get-usns:latest'
   args:
   - "--feed-url"
   - "${{ inputs.feed_url }}"


### PR DESCRIPTION
## Summary

This PR changes a few actions to use pre-built docker images rather than building them inline. This improves reliability as building these images has an observed failure rate of about 0.5%, or about 10 times per day across the Paketo stacks.

It doesn't have any noticeable impact on performance as the download time is comparable to the time taken to build the image.

## Background

The actions that have been changed are the ones that are used most commonly in the Stacks Poll USNs job, which runs on a schedule. We maintain seven stacks (Bionic Full, Base, Tiny and Jammy Full, Base, Tiny, Static), and each stack runs the Poll USNs job every 10 minutes. That means we run about 70 times per hour, or about 1700 times per day. We typically see about 10 failures per day, hence the 0.5% failure rate.

We have manually built and pushed these docker images to GitHub Container Registry - they can be seen on the [packages page](https://github.com/orgs/paketo-buildpacks/packages?sort_by=downloads_asc) for the Paketo Buildpacks organization.

## Future work

We should create a job that will build and push these images on a schedule. That can be done separately from this PR, however, as the images are not security-critical (they don't end up in any product or tool - they are just used in CI) so they can afford to be a little out of date.

Closes #625. See that issue for more context.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
