### PR TITLE
Publish stack build images to GCR.

### DIFF
--- a/stack/.github/workflows/push-image.yml
+++ b/stack/.github/workflows/push-image.yml
@@ -58,6 +58,9 @@ jobs:
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:latest"
 
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://gcr.io/${GCR_PROJECT}/build-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/build.oci" "docker://gcr.io/${GCR_PROJECT}/build-${{ steps.registry-repo.outputs.name }}:latest"
+
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:latest"
 
@@ -86,6 +89,7 @@ jobs:
           sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${variant}-cnb"
           sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run.oci" "docker://${DOCKERHUB_ORG}/run:${variant}"
 
+          sudo skopeo copy "docker://${DOCKERHUB_ORG}/build:${variant}-cnb" "docker://gcr.io/${GCR_PROJECT}/build:${variant}-cnb"
           sudo skopeo copy "docker://${DOCKERHUB_ORG}/run:${variant}-cnb" "docker://gcr.io/${GCR_PROJECT}/run:${variant}-cnb"
         fi
 


### PR DESCRIPTION
## Summary

This PR updates the stack image publishing step to push the build images for both Jammy and Bionic to Google Container Registry (GCR). This matches the existing behavior for run images, for both Jammy and Bionic.

In #603 we started to publish the run images for the Jammy stacks to Google Container Registry (GCR), to match the existing behavior of publishing the Bionic run images to GCR. However, we decided not to publish the build images to GCR because we weren't already publishing the Bionic build images.

It also pushes the Bionic build images to GCR under the legacy tag, for consistency with the Bionic run images.

## Use Cases

GCR can be a better option for some consumers than dockerhub, so pushing stack images to both can improve user experience at minimal cost to us.

Closes #628  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
