### PR TITLE
Remove unneccessary job in dependencies workflow.

### DIFF
--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -7,20 +7,8 @@ on:
     - cron: '0 */12 * * *'
 
 jobs:
-  select-go-version:
-    name: Select Go Version
-    runs-on: ubuntu-latest
-    outputs:
-      go-version: ${{ steps.select-go-version.outputs.go-version }}
-    steps:
-      - name: Select Go Version
-        id: select-go-version
-        run: echo "go-version=>=1.18.0" >> "$GITHUB_OUTPUT"
-
   retrieve:
     name: Retrieve New Versions and Generate Metadata
-    needs:
-      - select-go-version
     runs-on: ubuntu-latest
     outputs:
       metadata-filepath: ${{ steps.retrieve.outputs.metadata-filepath }}
@@ -35,10 +23,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Setup Go '${{ needs.select-go-version.outputs.go-version }}'
+      - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ needs.select-go-version.outputs.go-version }}
+          go-version: 1.18.x
 
       - name: Run Retrieve
         id: retrieve


### PR DESCRIPTION
## Summary

This PR removes an unnecessary job that was emitting a constant value for `go-version`.

Instead we hard-code the version of `go` to 1.18.x like we do everywhere else.

## Use Cases

Reduces code complexity and maintenance burden, as well as performance issues relating to having additional jobs requiring additional VMs.

Closes #591 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
