### PR TITLE
Ensure all instances of curl fail on error.

### DIFF
--- a/builder/scripts/.util/tools.sh
+++ b/builder/scripts/.util/tools.sh
@@ -54,6 +54,7 @@ function util::tools::jam::install() {
 
     util::print::title "Installing jam ${version}"
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
+      --fail \
       --silent \
       --location \
       --output "${dir}/jam"
@@ -101,6 +102,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+      --fail \
       --silent \
       --location \
       --output /tmp/pack.tgz

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -120,7 +120,12 @@ jobs:
       - name: Download upstream tarball (if not compiled)
         if: ${{ matrix.includes.uri != ''  && needs.get-compile-and-test.outputs.should-test == 'true' }}
         run: |
-          curl ${{ matrix.includes.uri }} --silent --location --output ${{ steps.make-outputdir.outputs.outputdir }}/dependency.tgz
+          curl ${{ matrix.includes.uri }} \
+            --fail-with-body \
+            --show-error \
+            --silent \
+            --location \
+            --output ${{ steps.make-outputdir.outputs.outputdir }}/dependency.tgz
 
       # Test the dependency tarball if:
       #   (1) dependency testing code is present in the buildpack directory

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -54,6 +54,7 @@ function util::tools::jam::install() {
 
     util::print::title "Installing jam ${version}"
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
+      --fail \
       --silent \
       --location \
       --output "${dir}/jam"
@@ -101,6 +102,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+      --fail \
       --silent \
       --location \
       --output /tmp/pack.tgz

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -54,6 +54,7 @@ function util::tools::jam::install() {
 
     util::print::title "Installing jam ${version}"
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
+      --fail \
       --silent \
       --location \
       --output "${dir}/jam"
@@ -101,6 +102,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+      --fail \
       --silent \
       --location \
       --output /tmp/pack.tgz

--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -54,6 +54,7 @@ function util::tools::jam::install() {
 
     util::print::title "Installing jam ${version}"
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
+      --fail \
       --silent \
       --location \
       --output "${dir}/jam"
@@ -101,6 +102,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+      --fail \
       --silent \
       --location \
       --output /tmp/pack.tgz
@@ -150,6 +152,7 @@ function util::tools::syft::install() {
 
     util::print::title "Installing syft ${version}"
     curl "https://github.com/anchore/syft/releases/download/${version}/syft_${version#v}_${os}_amd64.tar.gz" \
+      --fail \
       --silent \
       --location \
       --output /tmp/syft.tgz


### PR DESCRIPTION
## Summary

This PR ensures that all invocations of curl fail on error. See similar work in #554 (and #550) .

Workflows are guaranteed to run on jammy, so we can use the newer flags on those invocations. Other scripts might run with older versions of curl so only use the basic `--fail` flag.

## Use cases

This will help provide a more useful error when any of these curl invocations fail, rather than some more obscure downstream error.

See e.g. https://github.com/paketo-buildpacks/icu/issues/344

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
