### PR TITLE
Remove --unbuffered flag from stack creation.

### DIFF
--- a/actions/stack/create-stack/entrypoint
+++ b/actions/stack/create-stack/entrypoint
@@ -27,16 +27,6 @@ function main() {
 
   args=()
 
-  # If the repository name contains 'full' then we create the stack with
-  # the --unbuffered flag to avoid hitting memory limits in github
-  # workers
-  if [[ "${GITHUB_REPOSITORY}" == *-"full"-* ]]; then
-    echo "Full stack detected (${GITHUB_REPOSITORY}): running with --unbuffered flag"
-    args+=("--unbuffered")
-  else
-    echo "Non-full stack detected (${GITHUB_REPOSITORY}): omitting --unbuffered flag"
-  fi
-
   # Assigning a variable to an array in bash splits the variable on
   # whitespace, which includes new lines.
   # Therefore this assignment works whether the string is a single line

--- a/stack/scripts/create.sh
+++ b/stack/scripts/create.sh
@@ -20,9 +20,7 @@ if [[ $BASH_VERSINFO -lt 4 ]]; then
 fi
 
 function main() {
-  local unbuffered secrets
-
-  unbuffered="false"
+  local secrets
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
@@ -30,11 +28,6 @@ function main() {
         shift 1
         usage
         exit 0
-        ;;
-
-      --unbuffered)
-        unbuffered="true"
-        shift 1
         ;;
 
       --secret)
@@ -55,7 +48,7 @@ function main() {
   mkdir -p "${BUILD_DIR}"
 
   tools::install
-  stack::create "${unbuffered}" ${secrets[@]}
+  stack::create ${secrets[@]}
 }
 
 function usage() {
@@ -67,7 +60,6 @@ the repository.
 
 OPTIONS
   --help       -h   prints the command usage
-  --unbuffered      do not buffer image contents into memory for fast access
   --secret          provide a secret in the form key=value. Use flag multiple times to provide multiple secrets
 USAGE
 }
@@ -79,22 +71,14 @@ function tools::install() {
 }
 
 function stack::create() {
-  local unbuffered secrets
+  local secrets
 
-  unbuffered="${1}"
-  shift 1
   secrets=("${@}")
-
-  if [[ "${unbuffered}" == "true" ]]; then
-    echo "Running in unbuffered mode - this may take substantially longer"
-    echo
-  fi
 
   args=(
       --config "${STACK_DIR}/stack.toml"
       --build-output "${BUILD_DIR}/build.oci"
       --run-output "${BUILD_DIR}/run.oci"
-      --unbuffered="${unbuffered}"
     )
 
   for secret in "${secrets[@]}"; do


### PR DESCRIPTION
The `--unbuffered` flag was deprecated in jam as it no longer has any function. We can safely remove it from all our invocations.

Closes #648 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
