### PR TITLE
Switch to using Jammy as the default builder for integration testing

### DIFF
--- a/implementation/scripts/.util/builders.sh
+++ b/implementation/scripts/.util/builders.sh
@@ -19,7 +19,7 @@ function util::builders::list() {
 
   if [[ -z "${builders}" ]]; then
     util::print::info "No builders specified. Falling back to default builder..."
-    builders="$(jq --compact-output --null-input '["index.docker.io/paketobuildpacks/builder:buildpackless-base"]')"
+    builders="$(jq --compact-output --null-input '["index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"]')"
   fi
 
   echo "${builders}"

--- a/language-family/scripts/.util/builders.sh
+++ b/language-family/scripts/.util/builders.sh
@@ -19,7 +19,7 @@ function util::builders::list() {
 
   if [[ -z "${builders}" ]]; then
     util::print::info "No builders specified. Falling back to default builder..."
-    builders="$(jq --compact-output --null-input '["index.docker.io/paketobuildpacks/builder:buildpackless-base"]')"
+    builders="$(jq --compact-output --null-input '["index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"]')"
   fi
 
   echo "${builders}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Now the Jammy is fully supported across the project, we should switch to using as our default for testing.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
