### PR TITLE
issue file act: output node-id of created/mod issue

### DIFF
--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -32,10 +32,16 @@ inputs:
     description: '(Markdown) content of comment to add to preexisting issue. Required if comment_if_exists is true'
     required: false
 
+outputs:
+  node-id:
+    description: 'Universal node id of the output issue'
+    value: ${{ steps.file.outputs.node-id }}
+
 runs:
   using: 'composite'
   steps:
   - name: File Issue
+    id: file
     shell: bash
     env:
       GITHUB_TOKEN: ${{ inputs.token }}
@@ -44,6 +50,26 @@ runs:
       set -euo pipefail
 
       gh auth status
+
+      function output_node_id() {
+        local issue_number fullrepo repowner repoowner
+        fullrepo="${1}"
+        issue_number="${2}"
+
+        repoowner="${fullrepo%%/*}"
+        reponame="${fullrepo##*/}"
+
+        # gh cli does not yet support querying node ids directly
+        issue_node_id="$(gh api graphql -f query='
+          query($owner: String!, $name: String!, $issue_number: Int!) {
+            repository(owner: $owner, name: $name) {
+              issue(number: $issue_number) {
+                id
+              }
+            }
+          }' -f owner="$repoowner" -f name="$reponame" -F issue_number="$issue_number" --jq='.data.repository.issue.id')"
+        echo "node-id=${issue_node_id}" >> "$GITHUB_OUTPUT"
+      }
 
       if [[ "${{ inputs.comment_if_exists }}" == "true" ]]; then
         if [ -z "${{ inputs.label }}" ]; then
@@ -66,12 +92,15 @@ runs:
           gh issue comment "${issue_number}" \
             --body "${{ inputs.comment_body }}" \
             --repo "${{ inputs.repo }}"
+          output_node_id "${{ inputs.repo }}" "${issue_number}"
           exit 0
         fi
       fi
 
-      gh issue create \
+      issue_uri=$(gh issue create \
         --title "${{ inputs.issue_title }}" \
         --label "${{ inputs.label }}" \
         --body "${{ inputs.issue_body }}" \
-        --repo "${{ inputs.repo }}"
+        --repo "${{ inputs.repo }}")
+      issue_number=$(basename "${issue_uri}")
+      output_node_id "${{ inputs.repo }}" "${issue_number}"


### PR DESCRIPTION
Global node ID[1] of the issue can be used in subsequent jobs to perform an action on the created/edited issue.
E.g. add the issue to a project board etc.

gh cli does not yet have node-id support. So use gh graphql queries.

1: https://docs.github.com/en/graphql/guides/using-global-node-ids


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
