### PR TITLE
Add failure hooks for workflows.

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -120,3 +120,23 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates tools"
         branch: automation/tools/update
+
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update]
+    if: ${{ always() && needs.update.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-tools"
+        comment_if_exists: true
+        issue_title: "Failure: Update Tools workflow"
+        issue_body: |
+          Update Tools workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/approve-bot-pr.yml
+++ b/builder/.github/workflows/approve-bot-pr.yml
@@ -67,3 +67,22 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [download, approve]
+    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:approve-bot-pr"
+        comment_if_exists: true
+        issue_title: "Failure: Approve bot PR workflow"
+        issue_body: |
+          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/push-image.yml
+++ b/builder/.github/workflows/push-image.yml
@@ -50,3 +50,22 @@ jobs:
 
         docker push "${DOCKERHUB_ORG}/${registry_repo}:latest"
         docker push "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}"
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [push]
+    if: ${{ always() && needs.push.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:push"
+        comment_if_exists: true
+        issue_title: "Failure: Push Image workflow"
+        issue_body: |
+          Push Image workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -47,3 +47,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updating builder.toml"
         branch: "automation/builder-toml"
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update]
+    if: ${{ always() && needs.update.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update"
+        comment_if_exists: true
+        issue_title: "Failure: Update Builder TOML workflow"
+        issue_body: |
+          Update Builder TOML workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/update-github-config.yml
+++ b/builder/.github/workflows/update-github-config.yml
@@ -60,3 +60,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates github-config"
         branch: automation/github-config/update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-github-config"
+        comment_if_exists: true
+        issue_title: "Failure: Update GitHub config workflow"
+        issue_body: |
+          Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/approve-bot-pr.yml
+++ b/implementation/.github/workflows/approve-bot-pr.yml
@@ -67,3 +67,22 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [download, approve]
+    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:approve-bot-pr"
+        comment_if_exists: true
+        issue_title: "Failure: Approve bot PR workflow"
+        issue_body: |
+          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/go-get-update.yml
+++ b/implementation/.github/workflows/go-get-update.yml
@@ -50,3 +50,23 @@ jobs:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           title: "Running 'go get -u -t ./...'"
           branch: automation/tools/go-get-update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update]
+    if: ${{ always() && needs.update.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:go-get-update"
+          comment_if_exists: true
+          issue_title: "Failure: Go get update workflow"
+          issue_body: |
+            Go get update workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Please take a look to ensure CVE patches can be released. (cc @pivotal-cf/commercial-buildpacks).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/update-github-config.yml
+++ b/implementation/.github/workflows/update-github-config.yml
@@ -60,3 +60,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates github-config"
         branch: automation/github-config/update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-github-config"
+        comment_if_exists: true
+        issue_title: "Failure: Update GitHub config workflow"
+        issue_body: |
+          Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/approve-bot-pr.yml
+++ b/language-family/.github/workflows/approve-bot-pr.yml
@@ -67,3 +67,22 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [download, approve]
+    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:approve-bot-pr"
+        comment_if_exists: true
+        issue_title: "Failure: Approve bot PR workflow"
+        issue_body: |
+          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/update-buildpack-toml.yml
+++ b/language-family/.github/workflows/update-buildpack-toml.yml
@@ -46,3 +46,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates buildpacks in buildpack.toml"
         branch: automation/buildpack.toml/update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-buildpack-toml]
+    if: ${{ always() && needs.update-buildpack-toml.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-buildpack-toml"
+        comment_if_exists: true
+        issue_title: "Failure: Update Buildpack TOML workflow"
+        issue_body: |
+          Update Buildpack TOML workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/update-github-config.yml
+++ b/language-family/.github/workflows/update-github-config.yml
@@ -60,3 +60,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates github-config"
         branch: automation/github-config/update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-github-config"
+        comment_if_exists: true
+        issue_title: "Failure: Update GitHub config workflow"
+        issue_body: |
+          Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/library/.github/workflows/approve-bot-pr.yml
+++ b/library/.github/workflows/approve-bot-pr.yml
@@ -67,3 +67,22 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [download, approve]
+    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:approve-bot-pr"
+        comment_if_exists: true
+        issue_title: "Failure: Approve bot PR workflow"
+        issue_body: |
+          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/library/.github/workflows/update-github-config.yml
+++ b/library/.github/workflows/update-github-config.yml
@@ -61,3 +61,22 @@ jobs:
         title: "Updates github-config"
         branch: automation/github-config/update
         base: ${{ github.event.repository.default_branch }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-github-config"
+        comment_if_exists: true
+        issue_title: "Failure: Update GitHub config workflow"
+        issue_body: |
+          Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/stack/.github/workflows/approve-bot-pr.yml
+++ b/stack/.github/workflows/approve-bot-pr.yml
@@ -67,3 +67,22 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [download, approve]
+    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:approve-bot-pr"
+        comment_if_exists: true
+        issue_title: "Failure: Approve bot PR workflow"
+        issue_body: |
+          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/stack/.github/workflows/update-github-config.yml
+++ b/stack/.github/workflows/update-github-config.yml
@@ -60,3 +60,22 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         title: "Updates github-config"
         branch: automation/github-config/update
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-github-config"
+        comment_if_exists: true
+        issue_title: "Failure: Update GitHub config workflow"
+        issue_body: |
+          Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
## Summary
Add failure hooks for all workflows that do not have another mechanism for notification (e.g. a failed PR).

## Use Cases

Opening issues for failed workflows will increase visibility and lower the effort required to identify failing workflows.

Closes #664 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
