### PR TITLE
Ensure all actions exit on failure of sub-shell command.

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -17,7 +17,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       version="$(
         curl "https://api.github.com/repos/paketo-buildpacks/jam/releases/latest" \
           --fail-with-body \
@@ -33,7 +34,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       mkdir -p "${HOME}"/bin
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
@@ -49,6 +51,7 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       jam update-builder \
         --builder-file "${PWD}/builder.toml"

--- a/actions/buildpack/update/action.yml
+++ b/actions/buildpack/update/action.yml
@@ -23,7 +23,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       version=$(jq -r .jam "scripts/.util/tools.json")
       echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
@@ -31,7 +32,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       mkdir -p "${HOME}"/bin
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
@@ -47,8 +49,9 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
-        jam update-buildpack \
-          --buildpack-file "${PWD}/${{ inputs.buildpack_toml_path }}" \
-          --package-file "${PWD}/${{ inputs.package_toml_path }}" \
-          --no-cnb-registry="${{ inputs.no_cnb_registry }}"
+      set -euo pipefail
+      shopt -s inherit_errexit
+      jam update-buildpack \
+        --buildpack-file "${PWD}/${{ inputs.buildpack_toml_path }}" \
+        --package-file "${PWD}/${{ inputs.package_toml_path }}" \
+        --no-cnb-registry="${{ inputs.no_cnb_registry }}"

--- a/actions/dependency/update-from-metadata/action.yml
+++ b/actions/dependency/update-from-metadata/action.yml
@@ -25,7 +25,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       version=$(jq -r .jam "scripts/.util/tools.json")
       echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
@@ -33,7 +34,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       mkdir -p "${HOME}"/bin
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
@@ -48,7 +50,8 @@ runs:
     id: update
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       versions="$(
         jam update-dependencies \
           --buildpack-file "${{ inputs.buildpack_toml_path }}" \

--- a/actions/dependency/update/action.yml
+++ b/actions/dependency/update/action.yml
@@ -17,7 +17,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       version=$(jq -r .jam "scripts/.util/tools.json")
       echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
@@ -25,7 +26,8 @@ runs:
     shell: bash
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       mkdir -p "${HOME}"/bin
       echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
       mkdir -p "${HOME}/bin"
@@ -42,7 +44,8 @@ runs:
     id: update
     run: |
       #!/usr/bin/env bash
-      set -eu
+      set -euo pipefail
+      shopt -s inherit_errexit
       versions="$(
         jam update-dependencies \
           --buildpack-file "${PWD}/buildpack.toml"

--- a/actions/dependency/upload-to-s3/action.yml
+++ b/actions/dependency/upload-to-s3/action.yml
@@ -26,6 +26,7 @@ runs:
       run: |
         #!/usr/bin/env bash
         set -euo pipefail
+        shopt -s inherit_errexit
 
         filename="$(basename '${{ inputs.artifact-path }}')"
 

--- a/actions/issue/file/action.yml
+++ b/actions/issue/file/action.yml
@@ -48,6 +48,7 @@ runs:
     run: |
       #!/usr/bin/env bash
       set -euo pipefail
+      shopt -s inherit_errexit
 
       gh auth status
 

--- a/actions/pull-request/approve/entrypoint
+++ b/actions/pull-request/approve/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token number

--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local repo number author patchfiles

--- a/actions/pull-request/check-human-commits/entrypoint
+++ b/actions/pull-request/check-human-commits/entrypoint
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token repo number botsString

--- a/actions/pull-request/check-unverified-commits/entrypoint
+++ b/actions/pull-request/check-unverified-commits/entrypoint
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token repo number

--- a/actions/pull-request/checkout-branch/entrypoint
+++ b/actions/pull-request/checkout-branch/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local branch

--- a/actions/pull-request/create-commit/entrypoint
+++ b/actions/pull-request/create-commit/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local message pathspec committer_name committer_email keyid key

--- a/actions/pull-request/merge/entrypoint
+++ b/actions/pull-request/merge/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token number

--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token title body branch base

--- a/actions/pull-request/push-branch/entrypoint
+++ b/actions/pull-request/push-branch/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local branch

--- a/actions/pull-request/rebase/entrypoint
+++ b/actions/pull-request/rebase/entrypoint
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token number

--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local depth pattern repo strict

--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -1,8 +1,6 @@
 #!/bin/bash
-
-set -e
-set -u
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token repo buildpackage_path

--- a/actions/stack/create-stack/entrypoint
+++ b/actions/stack/create-stack/entrypoint
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
-set -eu
-set -o pipefail
+set -euo pipefail
 shopt -s inherit_errexit
 
 function main() {

--- a/actions/stack/generate-package-list/action.yml
+++ b/actions/stack/generate-package-list/action.yml
@@ -20,6 +20,7 @@ runs:
     run: |
       #!/usr/bin/env bash
       set -euo pipefail
+      shopt -s inherit_errexit
 
       packages=$(jq  '.components[] |  .name' "${{ inputs.build_receipt }}" "${{ inputs.run_receipt }}" \
         | jq --null-input --compact-output '[inputs]')

--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-
-set -e
-set -u
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local workspace config

--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -1,10 +1,9 @@
 #!/bin/sh
+set -euo pipefail
+shopt -s inherit_errexit
 
 # requires run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 # before executing this script
-
-set -eu
-set -o pipefail
 
 main() {
   local current_version allow_head_tagged

--- a/actions/tools/latest/entrypoint
+++ b/actions/tools/latest/entrypoint
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-
-set -e
-set -u
-set -o pipefail
+set -euo pipefail
+shopt -s inherit_errexit
 
 function main() {
   local token repo

--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -81,7 +81,9 @@ jobs:
     - name: Update Release Notes
       if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
       run: |
-        set -e
+        set -euo pipefail
+        shopt -s inherit_errexit
+
         payload="{\"body\" : \"\`\`\`\n${RELEASE_BODY}\n\`\`\`\"}"
 
         curl --fail \


### PR DESCRIPTION
## Summary

This change ensures that during execution of GitHub Actions, errors inside subshells/sub-commands are propagated to the caller. When coupled with `set -e` this ensures the scripts fail when they encounter a sub-shell error.

Without this change, errors in subshells are ignored and the scripts tend to fail later on in a less discoverable manner.

## Use Cases

This change improves visibility of GitHub Actions faliures - ensuring failures are reported when they fail, rather than in a less discoverable manner later on

## Additional Context

We can update all invocations that occur during GitHub actions because we config all of our actions to run on Ubuntu Jammy, which has a sufficiently recent version of Bash to support this command.

Do not modify scripts because they might be run outside of CI on older versions of Bash. In particular, Mac OS does not ship with a recent enough version of Bash out of the box.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
