### PR TITLE
Fix broken tag action.

### DIFF
--- a/actions/tag/increment-tag/Dockerfile
+++ b/actions/tag/increment-tag/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine/git
 
+RUN apk add \
+      bash \
+    && rm -rf /var/cache/apk/*
+
 COPY entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]

--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s inherit_errexit
 


### PR DESCRIPTION
## Summary

In #669 we introduced `shopt` everywhere, but the `increment-tag` action was using `/bin/sh` instead of a recent version of `bash`. This PR fixes this action.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
