### PR TITLE
Remove unnecessary parentheses from release issue title

### DIFF
--- a/language-family/.github/workflows/create-release-issue.yml
+++ b/language-family/.github/workflows/create-release-issue.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          issue_title: "Week of (${{ steps.date.outputs.day_of_month }}): Cut buildpack releases"
+          issue_title: "Week of ${{ steps.date.outputs.day_of_month }}: Cut buildpack releases"
           issue_body: ""
 
       - name: Add issue to project


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

File release reminder issue without unnecessary parentheses in the title:
`Week of (Feb 02): Cut buildpack releases` => `Week of Feb 02: Cut buildpack releases`

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
