### PR TITLE
fix sync action fails on non-existing dir in target repo

### DIFF
--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -30,6 +30,7 @@ function main() {
   for dir in "${directories[@]}"; do
     local src dest
     src="$(cd "${config}/${dir}" && pwd)/"
+    mkdir -p "${workspace}/${dir}"
     dest="$(cd "${workspace}/${dir}" && pwd)/"
 
     echo "syncing from ${src} to ${dest}"


### PR DESCRIPTION
## Summary

Make sure the target directory exists.

Example failure: https://github.com/paketo-buildpacks/occam/actions/runs/4080558752/jobs/7033137359

@ryanmoran I don't exactly know why you used the `"$(cd "${dir}" && pwd)/"` pattern. I guess this is to resolve any symlinks, right? So I think my `mkdir` should be fine.

BTW: The `src` dir does not need a `mkdir`, as we know it exists (we are looping over all src subdirs) 

## Use Cases

If we add a new folder to the `github-config` repo, syncing will no longer work.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
