### PR TITLE
Makes golangci-linter version latest

### DIFF
--- a/implementation/.github/workflows/lint.yml
+++ b/implementation/.github/workflows/lint.yml
@@ -24,5 +24,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.45.2
+        version: latest
         args: --timeout 3m0s

--- a/language-family/.github/workflows/lint.yml
+++ b/language-family/.github/workflows/lint.yml
@@ -24,5 +24,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.45.2
+        version: latest
         args: --timeout 3m0s


### PR DESCRIPTION
Running golangci-linter on Go 1.19 is not supported until [1.48.0](https://github.com/golangci/golangci-lint/releases/tag/v1.48.0) meaning the latest update to Go 1.19 in our actions is causing the lint action to fail. I have updated to always pull the latest to hopefully avoid this in the future.