### PR TITLE
stack/release-notes: avoid CVE section when scanning not done

### DIFF
--- a/actions/stack/release-notes/entrypoint/template.md
+++ b/actions/stack/release-notes/entrypoint/template.md
@@ -79,25 +79,23 @@ No packages modified.
 No packages removed.
 {{- end }}
 
+{{- if or .BuildCveReport .RunCveReport}}
 ## Known CVEs
 This section lists known CVEs of Critical, High and Unknown severity.
 
+{{if .BuildCveReport }}
 ### Build Image
-{{- if .BuildCveReport }}
 <details>
 <summary>Table</summary>
 {{.BuildCveReport}}
 </details>
-{{- else }}
-No known CVEs.
 {{- end }}
 
+{{if .RunCveReport }}
 ### Run Image
-{{- if .RunCveReport }}
 <details>
 <summary>Table</summary>
 {{.RunCveReport}}
 </details>
-{{- else }}
-No known CVEs.
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This is a follow-up to: https://github.com/paketo-buildpacks/github-config/pull/693

We do not want to print "No known CVEs" when CVE scanning itself is not performed.
e.g. https://github.com/paketo-buildpacks/jammy-full-stack/releases/tag/v0.0.70


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
