### PR TITLE
Add workflow failure labels to synchronized labels

### DIFF
--- a/builder/.github/labels.yml
+++ b/builder/.github/labels.yml
@@ -34,3 +34,12 @@
 - name: "failure:push"
   description: An issue filed automatically when a push buildpackage workflow run fails
   color: f00a0a
+- name: "failure:update-builder-toml"
+  description: An issue filed automatically when a builder.toml update workflow run fails
+  color: f00a0a
+- name: "failure:update-github-config"
+  description: An issue filed automatically when a github config update workflow run fails
+  color: f00a0a
+- name: "failure:approve-bot-pr"
+  description: An issue filed automatically when a PR auto-approve workflow run fails
+  color: f00a0a

--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repo: ${{ github.repository }}
-        label: "failure:update"
+        label: "failure:update-builder-toml"
         comment_if_exists: true
         issue_title: "Failure: Update Builder TOML workflow"
         issue_body: |

--- a/implementation/.github/labels.yml
+++ b/implementation/.github/labels.yml
@@ -34,6 +34,15 @@
 - name: "failure:push"
   description: An issue filed automatically when a push buildpackage workflow run fails
   color: f00a0a
-- name: "failure/update-dependencies"
+- name: "failure:update-dependencies"
   description: An issue filed automatically when updating buildpack.toml dependencies fails in a workflow
+  color: f00a0a
+- name: "failure:go-get-update"
+  description: An issue filed automatically when a go get update workflow run fails
+  color: f00a0a
+- name: "failure:update-github-config"
+  description: An issue filed automatically when a github config update workflow run fails
+  color: f00a0a
+- name: "failure:approve-bot-pr"
+  description: An issue filed automatically when a PR auto-approve workflow run fails
   color: f00a0a

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -341,7 +341,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}
-          label: "failure/update-dependencies"
+          label: "failure:update-dependencies"
           comment_if_exists: true
           issue_title: "Failure: Update Dependencies workflow"
           issue_body: |

--- a/language-family/.github/labels.yml
+++ b/language-family/.github/labels.yml
@@ -34,3 +34,12 @@
 - name: "failure:push"
   description: An issue filed automatically when a push buildpackage workflow run fails
   color: f00a0a
+- name: "failure:update-buildpack-toml"
+  description: An issue filed automatically when a buildpack.toml update workflow run fails
+  color: f00a0a
+- name: "failure:update-github-config"
+  description: An issue filed automatically when a github config update workflow run fails
+  color: f00a0a
+- name: "failure:approve-bot-pr"
+  description: An issue filed automatically when a PR auto-approve workflow run fails
+  color: f00a0a

--- a/library/.github/labels.yml
+++ b/library/.github/labels.yml
@@ -31,6 +31,9 @@
 - name: "failure:release"
   description: An issue filed automatically when a release workflow run fails
   color: f00a0a
-- name: "failure:push"
-  description: An issue filed automatically when a push buildpackage workflow run fails
+- name: "failure:update-github-config"
+  description: An issue filed automatically when a github config update workflow run fails
+  color: f00a0a
+- name: "failure:approve-bot-pr"
+  description: An issue filed automatically when a PR auto-approve workflow run fails
   color: f00a0a

--- a/stack/.github/labels.yml
+++ b/stack/.github/labels.yml
@@ -34,3 +34,9 @@
 - name: "failure:push"
   description: An issue filed automatically when a push stack images workflow run fails
   color: f00a0a
+- name: "failure:update-github-config"
+  description: An issue filed automatically when a github config update workflow run fails
+  color: f00a0a
+- name: "failure:approve-bot-pr"
+  description: An issue filed automatically when a PR auto-approve workflow run fails
+  color: f00a0a


### PR DESCRIPTION
## Summary

This PR ensures that the labels that are synchronized across the various
repositories are consistent with what the workflow failure-handlers expect.

Additionally:

* Ensure that the format of all failure labels is consistent (i.e. all failure
  labels follow the pattern `failure:some-type`)
* Remove unused labels (e.g. library repositories do not have a push workflow
  so the `failure:push` label is unneccessary).

## Use Cases

Some of the failure hooks that open issues for workflow failures are themselves
failing because the repositories do not have the required labels.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
