### PR TITLE
Update `mheap/github-action-required-labels` to v3

### DIFF
--- a/implementation/.github/workflows/label-pr.yml
+++ b/implementation/.github/workflows/label-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check Minimal Semver Labels
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v3
       with:
         count: 1
         labels: semver:major, semver:minor, semver:patch

--- a/language-family/.github/workflows/label-pr.yml
+++ b/language-family/.github/workflows/label-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check Minimal Semver Labels
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v3
       with:
         count: 1
         labels: semver:major, semver:minor, semver:patch

--- a/library/.github/workflows/label-pr.yml
+++ b/library/.github/workflows/label-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check Minimal Semver Labels
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v3
       with:
         count: 1
         labels: semver:major, semver:minor, semver:patch


### PR DESCRIPTION
## Summary

According to the documentation, both major updates should not break us

## Use Cases

Keep dependencies up-to-date

Also, the updated version of the action uses the new way of writing outputs ([see this blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)), but as we don't consume the output anywhere it probably doesn't matter. On the other hand, updating it makes it easier for me to track progress on the migration.

**UPDATE**

After reading the blog again, I guess it doesn't matter, if we use the output or not:

> Starting 1st June 2023 workflows using save-state or set-output commands via stdout **will fail with an error.**


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
