### PR TITLE
Allow use of GitHub token when downloading assets (jam, pack, etc).

### DIFF
--- a/builder/scripts/.util/tools.sh
+++ b/builder/scripts/.util/tools.sh
@@ -17,11 +17,18 @@ function util::tools::path::export() {
 }
 
 function util::tools::jam::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -49,15 +56,27 @@ function util::tools::jam::install() {
   util::tools::path::export "${dir}"
 
   if [[ ! -f "${dir}/jam" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .jam "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/jam"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+
     util::print::title "Installing jam ${version}"
+
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
-      --fail \
-      --silent \
-      --location \
-      --output "${dir}/jam"
+      "${curl_args[@]}"
+
     chmod +x "${dir}/jam"
   else
     util::print::title "Using $("${dir}"/jam version)"
@@ -65,11 +84,18 @@ function util::tools::jam::install() {
 }
 
 function util::tools::pack::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -97,18 +123,31 @@ function util::tools::pack::install() {
   esac
 
   if [[ ! -f "${dir}/pack" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    tmp_location="/tmp/pack.tgz"
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${tmp_location}"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
     util::print::title "Installing pack ${version}"
+
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
-      --fail \
-      --silent \
-      --location \
-      --output /tmp/pack.tgz
-    tar xzf /tmp/pack.tgz -C "${dir}"
+      "${curl_args[@]}"
+
+    tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
-    rm /tmp/pack.tgz
+
+    rm "${tmp_location}"
   else
     util::print::info "Using pack $("${dir}"/pack version)"
   fi

--- a/builder/scripts/smoke.sh
+++ b/builder/scripts/smoke.sh
@@ -13,7 +13,8 @@ source "${PROGDIR}/.util/tools.sh"
 source "${PROGDIR}/.util/print.sh"
 
 function main() {
-  local name
+  local name token
+  token=""
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
@@ -25,6 +26,11 @@ function main() {
 
       --name|-n)
         name="${2}"
+        shift 2
+        ;;
+
+      --token|-t)
+        token="${2}"
         shift 2
         ;;
 
@@ -46,7 +52,8 @@ function main() {
     name="testbuilder"
   fi
 
-  tools::install
+  tools::install "${token}"
+
   builder::create "${name}"
   image::pull::lifecycle "${name}"
   tests::run "${name}"
@@ -61,12 +68,17 @@ Runs the smoke test suite.
 OPTIONS
   --help        -h         prints the command usage
   --name <name> -n <name>  sets the name of the builder that is built for testing
+  --token <token>          Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
 USAGE
 }
 
 function tools::install() {
+  local token
+  token="${1}"
+
   util::tools::pack::install \
-    --directory "${BUILDERDIR}/.bin"
+    --directory "${BUILDERDIR}/.bin" \
+    --token "${token}"
 }
 
 function builder::create() {

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -17,11 +17,18 @@ function util::tools::path::export() {
 }
 
 function util::tools::jam::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -49,15 +56,27 @@ function util::tools::jam::install() {
   util::tools::path::export "${dir}"
 
   if [[ ! -f "${dir}/jam" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .jam "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/jam"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+
     util::print::title "Installing jam ${version}"
+
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
-      --fail \
-      --silent \
-      --location \
-      --output "${dir}/jam"
+      "${curl_args[@]}"
+
     chmod +x "${dir}/jam"
   else
     util::print::info "Using $("${dir}"/jam version)"
@@ -65,11 +84,18 @@ function util::tools::jam::install() {
 }
 
 function util::tools::pack::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -97,18 +123,31 @@ function util::tools::pack::install() {
   esac
 
   if [[ ! -f "${dir}/pack" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    tmp_location="/tmp/pack.tgz"
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${tmp_location}"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
     util::print::title "Installing pack ${version}"
+
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
-      --fail \
-      --silent \
-      --location \
-      --output /tmp/pack.tgz
-    tar xzf /tmp/pack.tgz -C "${dir}"
+      "${curl_args[@]}"
+
+    tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
-    rm /tmp/pack.tgz
+
+    rm "${tmp_location}"
   else
     util::print::info "Using pack $("${dir}"/pack version)"
   fi

--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -53,7 +53,7 @@ function main() {
       util::print::warn "** WARNING  No Integration tests **"
   fi
 
-  tools::install
+  tools::install "${GIT_TOKEN:-}"
 
   if [ ${#builderArray[@]} -eq 0 ]; then
     util::print::title "No builders provided. Finding builders in integration.json..."
@@ -97,11 +97,16 @@ USAGE
 }
 
 function tools::install() {
+  local token
+  token="${1}"
+
   util::tools::pack::install \
-    --directory "${BUILDPACKDIR}/.bin"
+    --directory "${BUILDPACKDIR}/.bin" \
+    --token "${token}"
 
   util::tools::jam::install \
-    --directory "${BUILDPACKDIR}/.bin"
+    --directory "${BUILDPACKDIR}/.bin" \
+    --token "${token}"
 
   util::tools::create-package::install \
     --directory "${BUILDPACKDIR}/.bin"

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -17,11 +17,18 @@ function util::tools::path::export() {
 }
 
 function util::tools::jam::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -49,15 +56,27 @@ function util::tools::jam::install() {
   util::tools::path::export "${dir}"
 
   if [[ ! -f "${dir}/jam" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .jam "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/jam"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+
     util::print::title "Installing jam ${version}"
+
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
-      --fail \
-      --silent \
-      --location \
-      --output "${dir}/jam"
+      "${curl_args[@]}"
+
     chmod +x "${dir}/jam"
   else
     util::print::info "Using $("${dir}"/jam version)"
@@ -65,11 +84,18 @@ function util::tools::jam::install() {
 }
 
 function util::tools::pack::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -97,18 +123,31 @@ function util::tools::pack::install() {
   esac
 
   if [[ ! -f "${dir}/pack" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    tmp_location="/tmp/pack.tgz"
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${tmp_location}"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
     util::print::title "Installing pack ${version}"
+
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
-      --fail \
-      --silent \
-      --location \
-      --output /tmp/pack.tgz
-    tar xzf /tmp/pack.tgz -C "${dir}"
+      "${curl_args[@]}"
+
+    tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
-    rm /tmp/pack.tgz
+
+    rm "${tmp_location}"
   else
     util::print::info "Using pack $("${dir}"/pack version)"
   fi

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -15,8 +15,10 @@ source "${PROGDIR}/.util/print.sh"
 source "${PROGDIR}/.util/builders.sh"
 
 function main() {
-  local builderArray
+  local builderArray token
   builderArray=()
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --help|-h)
@@ -27,6 +29,12 @@ function main() {
 
       --builder|-b)
         builderArray+=("${2}")
+        shift 2
+        ;;
+
+
+      --token|-t)
+        token="${2}"
         shift 2
         ;;
 
@@ -44,7 +52,7 @@ function main() {
     util::print::warn "** WARNING  No Integration tests **"
   fi
 
-  tools::install
+  tools::install "${token}"
 
   if [ ${#builderArray[@]} -eq 0 ]; then
     util::print::title "No builders provided. Finding builders in integration.json..."
@@ -83,15 +91,21 @@ OPTIONS
   --help           -h         prints the command usage
   --builder <name> -b <name>  sets the name of the builder(s) that are pulled / used for testing.
                               Defaults to "builders" array in integration.json, if present.
+  --token <token>             Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
 USAGE
 }
 
 function tools::install() {
+  local token
+  token="${1}"
+
   util::tools::pack::install \
-    --directory "${BUILDPACKDIR}/.bin"
+    --directory "${BUILDPACKDIR}/.bin" \
+    --token "${token}"
 
   util::tools::jam::install \
-    --directory "${BUILDPACKDIR}/.bin"
+    --directory "${BUILDPACKDIR}/.bin" \
+    --token "${token}"
 }
 
 function images::pull() {

--- a/language-family/scripts/package.sh
+++ b/language-family/scripts/package.sh
@@ -15,7 +15,8 @@ source "${ROOT_DIR}/scripts/.util/tools.sh"
 source "${ROOT_DIR}/scripts/.util/print.sh"
 
 function main {
-  local version output
+  local version output token
+  token=""
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
@@ -26,6 +27,11 @@ function main {
 
       --output|-o)
         output="${2}"
+        shift 2
+        ;;
+
+      --token|-t)
+        token="${2}"
         shift 2
         ;;
 
@@ -57,7 +63,7 @@ function main {
 
   repo::prepare
 
-  util::tools::pack::install --directory "${BIN_DIR}"
+  tools::install "${token}"
 
   buildpack::archive "${version}"
   buildpackage::create "${output}"
@@ -73,6 +79,7 @@ OPTIONS
   --help               -h            prints the command usage
   --version <version>  -v <version>  specifies the version number to use when packaging the buildpack
   --output <output>    -o <output>   location to output the packaged buildpackage artifact (default: ${ROOT_DIR}/build/buildpackage.cnb)
+  --token <token>                    Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
 USAGE
 }
 
@@ -87,13 +94,24 @@ function repo::prepare() {
   export PATH="${BIN_DIR}:${PATH}"
 }
 
+function tools::install() {
+  local token
+  token="${1}"
+
+  util::tools::jam::install \
+    --directory "${BIN_DIR}" \
+    --token "${token}"
+
+  util::tools::pack::install \
+    --directory "${BIN_DIR}" \
+    --token "${token}"
+}
+
 function buildpack::archive() {
   local version
   version="${1}"
 
   util::print::title "Packaging buildpack into ${BUILD_DIR}/buildpack.tgz..."
-
-  util::tools::jam::install --directory "${BIN_DIR}"
 
   jam pack \
     --buildpack "${ROOT_DIR}/buildpack.toml" \

--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -17,11 +17,18 @@ function util::tools::path::export() {
 }
 
 function util::tools::jam::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -49,15 +56,27 @@ function util::tools::jam::install() {
   util::tools::path::export "${dir}"
 
   if [[ ! -f "${dir}/jam" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .jam "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/jam"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+
     util::print::title "Installing jam ${version}"
+
     curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
-      --fail \
-      --silent \
-      --location \
-      --output "${dir}/jam"
+      "${curl_args[@]}"
+
     chmod +x "${dir}/jam"
   else
     util::print::info "Using $("${dir}"/jam version)"
@@ -65,11 +84,18 @@ function util::tools::jam::install() {
 }
 
 function util::tools::pack::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -97,29 +123,49 @@ function util::tools::pack::install() {
   esac
 
   if [[ ! -f "${dir}/pack" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    tmp_location="/tmp/pack.tgz"
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${tmp_location}"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
     util::print::title "Installing pack ${version}"
+
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
-      --fail \
-      --silent \
-      --location \
-      --output /tmp/pack.tgz
-    tar xzf /tmp/pack.tgz -C "${dir}"
+      "${curl_args[@]}"
+
+    tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
-    rm /tmp/pack.tgz
+
+    rm "${tmp_location}"
   else
     util::print::info "Using pack $("${dir}"/pack version)"
   fi
 }
 
 function util::tools::syft::install() {
-  local dir
+  local dir token
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --directory)
         dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
         shift 2
         ;;
 
@@ -147,18 +193,31 @@ function util::tools::syft::install() {
   esac
 
   if [[ ! -f "${dir}/syft" ]]; then
-    local version
+    local version curl_args
+
     version="$(jq -r .syft "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    tmp_location="/tmp/syft.tgz"
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${tmp_location}"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
     util::print::title "Installing syft ${version}"
+
     curl "https://github.com/anchore/syft/releases/download/${version}/syft_${version#v}_${os}_amd64.tar.gz" \
-      --fail \
-      --silent \
-      --location \
-      --output /tmp/syft.tgz
-    tar xzf /tmp/syft.tgz -C "${dir}"
+      "${curl_args[@]}"
+
+    tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/syft"
-    rm /tmp/syft.tgz
+
+    rm "${tmp_location}"
   fi
 }
 

--- a/stack/scripts/test.sh
+++ b/stack/scripts/test.sh
@@ -14,8 +14,10 @@ source "${PROG_DIR}/.util/tools.sh"
 source "${PROG_DIR}/.util/print.sh"
 
 function main() {
-  local clean
+  local clean token
   clean="false"
+  token=""
+
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --help|-h)
@@ -29,6 +31,11 @@ function main() {
         clean="true"
         ;;
 
+      --token|-t)
+        token="${2}"
+        shift 2
+        ;;
+
       "")
         # skip if the argument is empty
         shift 1
@@ -39,7 +46,7 @@ function main() {
     esac
   done
 
-  tools::install
+  tools::install "${token}"
 
   if [[ "${clean}" == "true" ]]; then
     util::print::title "Cleaning up preexisting stack archives..."
@@ -65,17 +72,23 @@ ${STACK_DIR}/build/run.oci
 if they exist. Otherwise, first runs create.sh to create them.
 
 OPTIONS
-  --clean  -c  clears contents of stack output directory before running tests
-  --help   -h  prints the command usage
+  --clean         -c  clears contents of stack output directory before running tests
+  --token <token>     Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
+  --help          -h  prints the command usage
 USAGE
 }
 
 function tools::install() {
+  local token
+  token="${1}"
+
   util::tools::jam::install \
-    --directory "${STACK_DIR}/.bin"
+    --directory "${STACK_DIR}/.bin" \
+    --token "${token}"
 
   util::tools::pack::install \
-    --directory "${STACK_DIR}/.bin"
+    --directory "${STACK_DIR}/.bin" \
+    --token "${token}"
 
   util::tools::skopeo::check
 }


### PR DESCRIPTION
## Summary

This change only uses token if one is provided (and is non-empty). This results in backwards-compatibility for existing invocations that do not currently provide a token. It also means that human users do not have to provide a token to run these scripts.

## Use Cases

Enable invocations of these scripts to use tokens if desired. This is in service of #653, as authenticated requests (i.e. using a token) have much higher rate limits and hence this change should help reduce flakiness in CI.

#653 will remain open even after this PR is merged as there are other instances where requests to GitHub are made without authentication.

This change does not modify the CI scripts to pass tokens - that change should come once these scripts are synced to downstream repos. We start with allowing the scripts to accept a token to avoid any potential ordering issues where CI attempts to provide a token but the script is not yet able to receive one.

## Alternative implementations

Interestingly, GitHub silently ignores empty (or invalid) tokens for public assets. This means that an alternative implementation of this change would be to always provide a token header, regardless of the value of the token. However, only adding a token when one is provided more accurately captures the intent. It also protects against a potential future change where GitHub rejects empty tokens.

I also considered pulling the token from an environment variable, but I think it is better to continue with the established pattern of providing configuration via flags, rather than magically authenticating requests if possible.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
