### PR TITLE
update the `actions/upload-artifact` from v2 to v3

### DIFF
--- a/builder/.github/workflows/test-pull-request.yml
+++ b/builder/.github/workflows/test-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}

--- a/implementation/.github/workflows/test-pull-request.yml
+++ b/implementation/.github/workflows/test-pull-request.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}

--- a/language-family/.github/workflows/test-pull-request.yml
+++ b/language-family/.github/workflows/test-pull-request.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}

--- a/library/.github/workflows/test-pull-request.yml
+++ b/library/.github/workflows/test-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: event-payload
         path: ${{ github.event_path }}


### PR DESCRIPTION
## Summary

According to their [release notes](https://github.com/actions/upload-artifact/releases/tag/v3.0.0) this is a major bump because:

> With the update to Node 16, all scripts will now be run with Node 16 rather than Node 12.

I guess this is only relevant, if you provide some custom code that runs in the context of the action.
Therefore the update should be safe.

Also: Some workflows already use v3.

## Use Cases

Don't fall behind on dependencies

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
