### PR TITLE
update the `actions/setup-python` from v3 to v4

### DIFF
--- a/builder/.github/workflows/lint-yaml.yml
+++ b/builder/.github/workflows/lint-yaml.yml
@@ -19,7 +19,7 @@ jobs:
         path: github-config
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/implementation/.github/workflows/lint-yaml.yml
+++ b/implementation/.github/workflows/lint-yaml.yml
@@ -19,7 +19,7 @@ jobs:
         path: github-config
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/language-family/.github/workflows/lint-yaml.yml
+++ b/language-family/.github/workflows/lint-yaml.yml
@@ -19,7 +19,7 @@ jobs:
         path: github-config
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/library/.github/workflows/lint-yaml.yml
+++ b/library/.github/workflows/lint-yaml.yml
@@ -19,7 +19,7 @@ jobs:
         path: github-config
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 


### PR DESCRIPTION
## Summary

Update to the latest major version of `actions/setup-python`, which uses the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We already use it here: https://github.com/paketo-buildpacks/github-config/blob/0d8ff82ef5133a8e3d0f0b762ec1840d1c82a004/.github/workflows/lint-yaml.yml#L22 therefore I'm confident that the major version won't break us.

## Use Cases

Keep the pipelines alive

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
