### PR TITLE
Remove unused team cc from implementation go-get failure hook.

### DIFF
--- a/implementation/.github/workflows/go-get-update.yml
+++ b/implementation/.github/workflows/go-get-update.yml
@@ -67,6 +67,5 @@ jobs:
           issue_title: "Failure: Go get update workflow"
           issue_body: |
             Go get update workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-            Please take a look to ensure CVE patches can be released. (cc @pivotal-cf/commercial-buildpacks).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
## Summary

We don't want to cc this team. There isn't a single static team that covers all implementation buildpacks, so let's just delete the entire "cc" line.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
