### PR TITLE
Reduce frequency of stacks building to once per 30 mins.

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@ name: Create Release
 
 on:
   schedule:
-  - cron: '*/10 * * * *'  # every 10 minutes
+  - cron: '*/30 * * * *'  # every 30 minutes
   push:
     branches:
     - main


### PR DESCRIPTION
## Summary

This PR reduces the frequency of stack builds to once every 30 minutes instead of once every ten minutes.

## Use Cases

The primary reason for this is because the full stack takes 10-20 mins to create the stack, which in turn results in GHA runs being skipped fairly frequently

More generally, this reduces load/contention on GHA and reduces the total number of flakes per day as there are fewer builds running. Waiting an extra 20 minutes for a new stack should be an acceptable trade-off for consumers.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
