### PR TITLE
Help wanted labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,32 +19,11 @@
 - name: help wanted
   description: Extra attention is needed
   color: 008672
-- name: semver:major
-  description: A change requiring a major version bump
-  color: 6b230e
-- name: semver:minor
-  description: A change requiring a minor version bump
-  color: cc6749
-- name: semver:patch
-  description: A change requiring a patch version bump
-  color: f9d0c4
 - name: good first issue
   description: A good first issue to get started with
   color: d3fc03
-- name: "failure:release"
-  description: An issue filed automatically when a release workflow run fails
-  color: f00a0a
-- name: "failure:push"
-  description: An issue filed automatically when a push buildpackage workflow run fails
-  color: f00a0a
-- name: "failure:update-dependencies"
-  description: An issue filed automatically when updating buildpack.toml dependencies fails in a workflow
-  color: f00a0a
-- name: "failure:go-get-update"
-  description: An issue filed automatically when a go get update workflow run fails
-  color: f00a0a
-- name: "failure:update-github-config"
-  description: An issue filed automatically when a github config update workflow run fails
+- name: "failure:update-tools"
+  description: An issue filed automatically when a github tools update workflow run fails
   color: f00a0a
 - name: "failure:approve-bot-pr"
   description: An issue filed automatically when a PR auto-approve workflow run fails

--- a/.github/workflows/synchronize-labels.yml
+++ b/.github/workflows/synchronize-labels.yml
@@ -1,0 +1,18 @@
+name: Synchronize Labels
+"on":
+    push:
+        branches:
+            - main
+        paths:
+            - .github/labels.yml
+    workflow_dispatch: {}
+jobs:
+    synchronize:
+        name: Synchronize Labels
+        runs-on:
+            - ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v3
+            - uses: micnncim/action-label-syncer@v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}

--- a/builder/.github/labels.yml
+++ b/builder/.github/labels.yml
@@ -16,6 +16,9 @@
 - name: documentation
   description: This issue relates to writing documentation
   color: D4C5F9
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
 - name: semver:major
   description: A change requiring a major version bump
   color: 6b230e

--- a/language-family/.github/labels.yml
+++ b/language-family/.github/labels.yml
@@ -16,6 +16,9 @@
 - name: documentation
   description: This issue relates to writing documentation
   color: D4C5F9
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
 - name: semver:major
   description: A change requiring a major version bump
   color: 6b230e

--- a/library/.github/labels.yml
+++ b/library/.github/labels.yml
@@ -16,6 +16,9 @@
 - name: documentation
   description: This issue relates to writing documentation
   color: D4C5F9
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
 - name: semver:major
   description: A change requiring a major version bump
   color: 6b230e

--- a/stack/.github/labels.yml
+++ b/stack/.github/labels.yml
@@ -16,6 +16,9 @@
 - name: documentation
   description: This issue relates to writing documentation
   color: D4C5F9
+- name: help wanted
+  description: Extra attention is needed
+  color: 008672
 - name: semver:major
   description: A change requiring a major version bump
   color: 6b230e


### PR DESCRIPTION
## Summary / Use Cases

This PR adds the `help wanted` label (with the default color and description) to the various repositories. We have started using this label to indicate that we would like additional input, so we should ensure it is always available.

Additionally, this PR also adds labels (and the label-syncing workflow) to this repo itself.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
