### PR TITLE
Run integration tests with CGO_ENABLED=0

### DIFF
--- a/builder/scripts/smoke.sh
+++ b/builder/scripts/smoke.sh
@@ -108,6 +108,7 @@ function tests::run() {
 
   util::print::title "Run Builder Smoke Tests"
 
+  export CGO_ENABLED=0
   testout=$(mktemp)
   pushd "${BUILDERDIR}" > /dev/null
     if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./smoke/... -v -run Smoke --name "${name}" | tee "${testout}"; then

--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -149,6 +149,7 @@ function tests::run() {
   util::print::title "Run Buildpack Runtime Integration Tests"
   util::print::info "Using ${1} as builder..."
 
+  export CGO_ENABLED=0
   pushd "${BUILDPACKDIR}" > /dev/null
     if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${2}"; then
       util::print::info "** GO Test Succeeded with ${1}**"

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -135,6 +135,7 @@ function tests::run() {
   util::print::title "Run Buildpack Runtime Integration Tests"
   util::print::info "Using ${1} as builder..."
 
+  export CGO_ENABLED=0
   pushd "${BUILDPACKDIR}" > /dev/null
     #shellcheck disable=SC2068
     if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${2}"; then

--- a/stack/scripts/test.sh
+++ b/stack/scripts/test.sh
@@ -96,6 +96,7 @@ function tools::install() {
 function tests::run() {
   util::print::title "Run Stack Acceptance Tests"
 
+  export CGO_ENABLED=0
   testout=$(mktemp)
   pushd "${STACK_DIR}" > /dev/null
     if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./... -v -run Acceptance | tee "${testout}"; then


### PR DESCRIPTION
## Summary

This PR ensures that any Buildpacks that freezer builds during the tests (e.g. Java buildpacks, Watchexec, Procfile) are built with `CGO_ENABLED=0`. This is required for integration tests that use these Buildpacks to pass on the Bionic Stack/Builders.

## Use Cases

Fixes issues like [this](https://github.com/paketo-buildpacks/poetry-run/actions/runs/4670505493/jobs/8270330347#step:5:270):

```
[detector] ======== Output: paketo-buildpacks/watchexec@2.8.1 ========
[detector] /cnb/buildpacks/paketo-buildpacks_watchexec/2.8.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /cnb/buildpacks/paketo-buildpacks_watchexec/2.8.1/bin/detect)
[detector] /cnb/buildpacks/paketo-buildpacks_watchexec/2.8.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /cnb/buildpacks/paketo-buildpacks_watchexec/2.8.1/bin/detect)
```

and [this](https://github.com/paketo-buildpacks/bionic-base-stack/actions/runs/4674341131/jobs/8279551608?pr=135#step:6:201):

```
[detector] ======== Output: paketo-buildpacks/sap-machine@10.1.1 ========
[detector] /cnb/buildpacks/paketo-buildpacks_sap-machine/10.1.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /cnb/buildpacks/paketo-buildpacks_sap-machine/10.1.1/bin/detect)
[detector] /cnb/buildpacks/paketo-buildpacks_sap-machine/10.1.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /cnb/buildpacks/paketo-buildpacks_sap-machine/10.1.1/bin/detect)
[detector] ======== Output: paketo-buildpacks/syft@1.27.0 ========
[detector] /cnb/buildpacks/paketo-buildpacks_syft/1.27.0/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /cnb/buildpacks/paketo-buildpacks_syft/1.27.0/bin/detect)
[detector] /cnb/buildpacks/paketo-buildpacks_syft/1.27.0/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /cnb/buildpacks/paketo-buildpacks_syft/1.27.0/bin/detect)
[detector] ======== Output: paketo-buildpacks/maven@6.14.1 ========
[detector] /cnb/buildpacks/paketo-buildpacks_maven/6.14.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /cnb/buildpacks/paketo-buildpacks_maven/6.14.1/bin/detect)
[detector] /cnb/buildpacks/paketo-buildpacks_maven/6.14.1/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /cnb/buildpacks/paketo-buildpacks_maven/6.14.1/bin/detect)
[detector] ======== Output: paketo-buildpacks/executable-jar@6.6.3 ========
[detector] /cnb/buildpacks/paketo-buildpacks_executable-jar/6.6.3/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /cnb/buildpacks/paketo-buildpacks_executable-jar/6.6.3/bin/detect)
[detector] /cnb/buildpacks/paketo-buildpacks_executable-jar/6.6.3/bin/detect: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /cnb/buildpacks/paketo-buildpacks_executable-jar/6.6.3/bin/detect)
```

## Alternatives

There are multiple ways to solve the underlying issue that some Buildpacks aren't compatible with the stack during the integration tests:

1. Include the relevant `glibc` headers for the Bionic stack when compiling with dynamic linking.
    * I ruled this out because I don't know how to do this. It sounds really hard. I'm not sure it's a sensible thing to do.
    * In general `CGO_ENABLED=0` offers other benefits - mostly around ease of debugging system-integration issues (because you have fewer/no interactions with libraries).
1. Only run our tests on Bionic machines, so that when we compile with dynamically linking the host has the same version of `glibc` as the target.
    * I ruled this out because it's a bad idea to revert to older OSs for tests. We'd have to manually install newer versions of many packages that we use on the host VMs.
1. Modify [pipeline-builder](https://github.com/paketo-buildpacks/pipeline-builder) to attach the pre-packaged buildpacks to the GitHub release, similar to what other Paketo buildpacks do.
    * I ruled this out because it would take a while for me to implement the change in pipeline-builder, and would require releasing new versions of pipeline-builder, and then of every buildpack. The feedback loop on this option is quite long (order of days to weeks).
1. Modify the various `build.sh` scripts (e.g. for [watchexec](https://github.com/paketo-buildpacks/watchexec/blob/145bf6875a17e8c220998537fba4990e4dbd9736/scripts/build.sh#L5)) that freezer uses to package up the buildpacks when it cannot find a pre-packaged asset to download.
    * I ruled this out because it requires opening PRs to a lot of repos. There is about 30 buildpacks that this would apply to.
    * Not all of the repositories would have to be modified because not all the repositories are used during freezer-based integration tests. However, that would cause divergence across the buildpacks and is likely to lead to further confusion.
1. Modify [pipeline-builder](https://github.com/paketo-buildpacks/pipeline-builder) to take ownership of the [`build.sh`](https://github.com/paketo-buildpacks/watchexec/blob/145bf6875a17e8c220998537fba4990e4dbd9736/scripts/build.sh#L5) scripts and do the above
    * I ruled this out for similar reasons as the first option - it would require making a new release of `pipeline-builder` and then each of the buildpacks, resulting in a fairly long feedback loop.
    * Additionally, there's a possibility that not all `build.sh` scripts are currently identical, which would introduce risk and complexity to find a way to centralize that ownership without introducing regressions in the existing packaging process
1. Modify freezer to be able to download images from dockerhub in addition to GitHub releases. All pre-packaged buildpacks on dockerhub/GCR are already compiled with `CGO_ENABLED=0` and so would just work out of the box if freezer could download them instead of having to re-package the pipeline-builder buildpacks.
    * I ruled this out because it's a lot of work to modify freezer to support this use-case. And it's not even clear if it makes sense within the scope of freezer. What would it mean to download a docker image and unpack it to be freezer-cache-compliant?
1. Modify the test scripts to pull images from dockerhub before running the integration tests
    * I ruled this out because it's a fair bit of work, and because it's not obvious how this would work for offline test cases - we don't publish images with dependencies so we'd still have to package them up during the offline tests.
    * This is similar to above, but moving the logic out of freezer and into the test setup
    * This would essentially bypass freezer altogether, and rely on docker for caching, etc
    * This is what the integration tests do for the builders

## Detailed explanation

- This ensures that any buildpacks that freezer builds during the tests (e.g. Java buildpacks, Watchexec, Procfile) are built with `CGO_ENABLED=0`. This is required for these Buildpacks to run on the Bionic stack/builders.
- This change is required because of the following:
  * As of go 1.20+, the go toolchain does not have pre-compiled headers for multiple versions of glibc.
  * This means that any dynamically-linked binaries built with go 1.20+ will not run on targets with older versions of `glibc` than what was on the host.
  * We typically build the Buildpack binaries on `Jammy`, so without any modifications to the build process, these Buildpacks will not run on Bionic.
  * Building the binaries with `CGO_ENABLED=0` ensures that the binaries are statically linked, and therefore will run on older versions of `glibc` (i.e. binaries compiled on Jammy hosts will run on the Bionic stack).
  * All buildpacks are built with `CGO_ENABLED=0` for production, but the buildpacks built using [pipeline-builder](https://github.com/paketo-buildpacks/pipeline-builder) do not publish these pre-built/pre-packaged artifacts on their GitHub release pages.
  * As a result, the [freezer](https://github.com/ForestEckhardt/freezer) library is unable to download pre-packaged artifacts for those buildpacks, and must build them from source during the integration tests.
  * Therefore `CGO_ENABLED=0` must be set so that freezer can build these buildpacks in a way that works on the Bionic stack when running the integration tests on a Jammy host.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
