### PR TITLE
install curl-dev in tool update action

### DIFF
--- a/actions/tools/latest/Dockerfile
+++ b/actions/tools/latest/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine/git
 RUN apk add \
       bash \
       curl \
+      curl-dev \
       jq \
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #749 
We recently started seeing this workflow fail on the `actions/tools/latest` action step for updating `jam` with `curl: (48) An unknown option was passed in to libcurl`. Installing `curl-dev` resolves this error, although I'm not entirely sure _why_ this issue cropped up in the first place.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
