### PR TITLE
Use os/architecture specific tools, dealing with varying tool artifact naming conventions

### DIFF
--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -6,6 +6,42 @@ set -o pipefail
 # shellcheck source=SCRIPTDIR/print.sh
 source "$(dirname "${BASH_SOURCE[0]}")/print.sh"
 
+function util::tools::os() {
+  case "$(uname)" in
+    "Darwin")
+      echo "${1:-darwin}"
+      ;;
+
+    "Linux")
+      echo "linux"
+      ;;
+
+    *)
+      util::print::error "Unknown OS \"$(uname)\""
+      exit 1
+  esac
+}
+
+function util::tools::arch() {
+  case "$(uname -m)" in
+    arm64|aarch64)
+      echo "arm64"
+      ;;
+
+    amd64|x86_64)
+      if [[ "${1:-}" == "--blank-amd64" ]]; then
+        echo ""
+      else
+        echo "amd64"
+      fi
+      ;;
+
+    *)
+      util::print::error "Unknown Architecture \"$(uname -m)\""
+      exit 1
+  esac
+}
+
 function util::tools::path::export() {
   local dir
   dir="${1}"
@@ -37,26 +73,11 @@ function util::tools::jam::install() {
     esac
   done
 
-  local os
-  case "$(uname)" in
-    "Darwin")
-      os="darwin"
-      ;;
-
-    "Linux")
-      os="linux"
-      ;;
-
-    *)
-      echo "Unknown OS \"$(uname)\""
-      exit 1
-  esac
-
   mkdir -p "${dir}"
   util::tools::path::export "${dir}"
 
   if [[ ! -f "${dir}/jam" ]]; then
-    local version curl_args
+    local version curl_args os arch
 
     version="$(jq -r .jam "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
@@ -71,10 +92,12 @@ function util::tools::jam::install() {
       curl_args+=("--header" "Authorization: Token ${token}")
     fi
 
-
     util::print::title "Installing jam ${version}"
 
-    curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}" \
+    os=$(util::tools::os)
+    arch=$(util::tools::arch)
+
+    curl "https://github.com/paketo-buildpacks/jam/releases/download/${version}/jam-${os}-${arch}" \
       "${curl_args[@]}"
 
     chmod +x "${dir}/jam"
@@ -107,23 +130,8 @@ function util::tools::pack::install() {
   mkdir -p "${dir}"
   util::tools::path::export "${dir}"
 
-  local os
-  case "$(uname)" in
-    "Darwin")
-      os="macos"
-      ;;
-
-    "Linux")
-      os="linux"
-      ;;
-
-    *)
-      echo "Unknown OS \"$(uname)\""
-      exit 1
-  esac
-
   if [[ ! -f "${dir}/pack" ]]; then
-    local version curl_args
+    local version curl_args os arch
 
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
@@ -141,7 +149,10 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
 
-    curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+    os=$(util::tools::os macos)
+    arch=$(util::tools::arch --blank-amd64)
+
+    curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}${arch:+-$arch}.tgz" \
       "${curl_args[@]}"
 
     tar xzf "${tmp_location}" -C "${dir}"
@@ -177,23 +188,8 @@ function util::tools::syft::install() {
   mkdir -p "${dir}"
   util::tools::path::export "${dir}"
 
-  local os
-  case "$(uname)" in
-    "Darwin")
-      os="darwin"
-      ;;
-
-    "Linux")
-      os="linux"
-      ;;
-
-    *)
-      echo "Unknown OS \"$(uname)\""
-      exit 1
-  esac
-
   if [[ ! -f "${dir}/syft" ]]; then
-    local version curl_args
+    local version curl_args os arch
 
     version="$(jq -r .syft "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
@@ -211,7 +207,10 @@ function util::tools::syft::install() {
 
     util::print::title "Installing syft ${version}"
 
-    curl "https://github.com/anchore/syft/releases/download/${version}/syft_${version#v}_${os}_amd64.tar.gz" \
+    os=$(util::tools::os)
+    arch=$(util::tools::arch)
+
+    curl "https://github.com/anchore/syft/releases/download/${version}/syft_${version#v}_${os}_${arch}.tar.gz" \
       "${curl_args[@]}"
 
     tar xzf "${tmp_location}" -C "${dir}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Currently, the tools that are used by various dependent projects assume `amd64` architecture even on `arm64` machines. These tools don't work on all `arm64` machines so we should use architecture specific versions of these tools when building stacks and buildpacks. Resolves #756

## Use Cases
The automation to build stacks and buildpacks should use architecture specific tools when running on `arm64` and `amd64` machines.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
