### PR TITLE
Add pagination handling for find-asset action

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -54,9 +54,11 @@ function find_asset() {
   pattern="${3}"
   strict="${4}"
 
-  release_json=$(gh api "repos/${repo}/releases"  \
+  release_json=$(gh api "repos/${repo}/releases?per_page=100"  \
     --method GET \
     --paginate \
+    | jq -s '[.[]]' \
+    | jq 'add' \
     | jq -r \
     --arg pattern "${pattern}" \
     --argjson depth "${depth}" \


### PR DESCRIPTION
## Summary

The action `actions/release/find-asset/entrypoint` retrieves all the releases with the GitHub API but it does not take into account cases in which pagination is activated (number of releases greater than 100) and therefore generates errors when obtaining them.

For the specific case of [Jammy Full Stack](https://github.com/paketo-buildpacks/jammy-full-stack), there are 101 releases in total, so the result of the command is something like this:

```json
[
  {"tag": "v0.0.2"}
  {"tag": "v0.0.3"}
  {"tag": "v0.0.4"}
  .
  .
  .
  {"tag": "v0.0.101"}
]
[
  {"tag": "v0.0.1"}
]
```

Note that the results are 2 sets of JSON arrays. With the proposed change, It will merge the JSON arrays  from the GitHub API response using `jq` into a single JSON.

Fix https://github.com/paketo-buildpacks/jammy-full-stack/issues/14 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
