### PR TITLE
stack: use consistent language: s/archive/image

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -148,8 +148,8 @@ jobs:
     - name: Generate Package Receipts
       id: receipts
       run: |
-        scripts/receipts.sh --build-archive "${GITHUB_WORKSPACE}/build/build.oci" \
-                            --run-archive "${GITHUB_WORKSPACE}/build/run.oci" \
+        scripts/receipts.sh --build-image "${GITHUB_WORKSPACE}/build/build.oci" \
+                            --run-image "${GITHUB_WORKSPACE}/build/run.oci" \
                             --build-receipt ${{ env.BUILD_RECEIPT_FILENAME }} \
                             --run-receipt ${{ env.RUN_RECEIPT_FILENAME }}
         echo "build_receipt=${{ env.BUILD_RECEIPT_FILENAME }}" >> "$GITHUB_OUTPUT"

--- a/stack/scripts/receipts.sh
+++ b/stack/scripts/receipts.sh
@@ -29,12 +29,12 @@ function main() {
         exit 0
         ;;
 
-      --build-archive|-b)
+      --build-image|-b)
         build="${2}"
         shift 2
         ;;
 
-      --run-archive|-r)
+      --run-image|-r)
         run="${2}"
         shift 2
         ;;
@@ -76,9 +76,9 @@ stack.
 
 OPTIONS
   --help          -h  prints the command usage
-  --build-archive -b  path to OCI archive of build image. Defaults to
+  --build-image   -b  path to OCI image of build image. Defaults to
                       ${BUILD_DIR}/build.oci
-  --run-archive   -r  path to OCI archive of build image
+  --run-image     -r  path to OCI image of build image
                       ${BUILD_DIR}/run.oci
   --build-receipt -B  path to output build image package receipt. Defaults to
                       ${BUILD_DIR}/build-receipt.txt
@@ -93,15 +93,15 @@ function tools::install() {
 }
 
 function receipts::generate() {
-  local archive output hasDpkg
+  local image output
 
-  archive="${1}"
+  image="${1}"
   output="${2}"
 
-  util::print::title "Generating package SBOM for ${archive}"
+  util::print::title "Generating package SBOM for ${image}"
 
   util::print::info "Generating CycloneDX package SBOM using syft"
-  syft packages "${archive}" --output cyclonedx-json --file "${output}"
+  syft packages "${image}" --output cyclonedx-json --file "${output}"
 }
 
 main "${@:-}"


### PR DESCRIPTION
Use the word "image" for the build/run OCI file as has been used widely in this shared github-config.

Archive is also used for filesystem tar archives produces by the likes of "docker export". This change avoids the chance of confusion

And, remove an unused variable

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
