### PR TITLE
action/find-asset: slice off first char only if it's a "v"

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -62,7 +62,7 @@ function find_asset() {
     | jq -r \
     --arg pattern "${pattern}" \
     --argjson depth "${depth}" \
-    'sort_by(.tag_name | .[1:] | split(".") | map(tonumber))
+    'sort_by(.tag_name | gsub("^v"; "")  | split(".") | map(tonumber))
     | reverse
     | map(select(.draft==false))
     | limit($depth; .)


### PR DESCRIPTION
Don't slice off the first character from every tag. It's true the all current buildpack/stack repos use tags of format "vX.Y.Z" but this change will make it usable for repos that just use "X.Y.Z"

