### PR TITLE
Pull builder images just before running integration tests.

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -61,17 +61,20 @@ function main() {
     local builders
     builders="$(util::builders::list "${BUILDPACKDIR}/integration.json" | jq -r '.[]' )"
 
+    util::print::info "Found the following builders:"
+    util::print::info "${builders}"
+
     # shellcheck disable=SC2206
     IFS=$'\n' builderArray=(${builders})
     unset IFS
   fi
 
-  # shellcheck disable=SC2068
-  images::pull ${builderArray[@]}
-
   local testout
   testout=$(mktemp)
   for builder in "${builderArray[@]}"; do
+    util::print::title "Getting images for builder: '${builder}'"
+    builder_images::pull "${builder}"
+
     util::print::title "Setting default pack builder image..."
     pack config default-builder "${builder}"
 
@@ -117,27 +120,28 @@ function tools::install() {
   fi
 }
 
-function images::pull() {
-  for builder in "${@}"; do
-    util::print::title "Pulling builder image ${builder}..."
-    docker pull "${builder}"
+function builder_images::pull() {
+  local builder
+  builder="${1}"
 
-    local run_image lifecycle_image
-    run_image="$(
-      pack inspect-builder "${builder}" --output json \
-        | jq -r '.remote_info.run_images[0].name'
-    )"
-    lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
-      pack inspect-builder "${builder}" --output json \
-        | jq -r '.remote_info.lifecycle.version'
-    )"
+  util::print::title "Pulling builder image ${builder}..."
+  docker pull "${builder}"
 
-    util::print::title "Pulling run image..."
-    docker pull "${run_image}"
+  local run_image lifecycle_image
+  run_image="$(
+    pack inspect-builder "${builder}" --output json \
+      | jq -r '.remote_info.run_images[0].name'
+  )"
+  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
+    pack inspect-builder "${builder}" --output json \
+      | jq -r '.remote_info.lifecycle.version'
+  )"
 
-    util::print::title "Pulling lifecycle image..."
-    docker pull "${lifecycle_image}"
-  done
+  util::print::title "Pulling run image..."
+  docker pull "${run_image}"
+
+  util::print::title "Pulling lifecycle image..."
+  docker pull "${lifecycle_image}"
 }
 
 function token::fetch() {


### PR DESCRIPTION
# Summary

Some of the tests (e.g. stack upgrade) will explicitly pull and remove images for other builders, which means by the time the next test runs the pre-pulled images for that other builder have been removed.

By pulling builder images (including the lifecycle and run image) just before the specific test runs, we guarantee that the necessary images are present.

## Use Cases

Tests pass when run serially (e.g. locally) across builders for different stacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
