### PR TITLE
Run post-sync hook if it exists during sync action.

### DIFF
--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -51,7 +51,24 @@ function main() {
       )
     fi
 
+    if [[ -f "${dest}/.sync-post-hook" ]]; then
+      args+=(
+        --exclude=".sync-post-hook"
+        --exclude-from="${dest}/.sync-post-hook"
+      )
+    fi
+
     bash -c "rsync ${args[*]}"
+
+    echo
+    echo "sync complete"
+    echo
+
+    post_hook_filepath="${dest}/.sync-post-hook"
+    if [[ -f "${post_hook_filepath}" ]]; then
+      echo "running post hook at: '${post_hook_filepath}'"
+      bash -c "${post_hook_filepath}"
+    fi
 
     echo
   done


### PR DESCRIPTION
## Summary

This PR adds support for arbitrary behavior after syncing via a `.github/.sync-post-hook` file. If the file exists, it is executed after the syncing process. If the file does not exist, the action does not attempt to execute it.

I have tested this locally - and it works as described above - but it's a lot of work to demonstrate this working in a CI environment so I'd like to merge this without needing to set up branches on an example repository to show the functionality.

## Use Cases

This provides a simple yet powerful mechanism to make repository-specific changes to files that are synced from the common/shared location. A good example of this is running `ytt` to make changes to a workflow file that should only exist for some repositories (e.g. running on a custom/self-hosted runner).

It could also provide a useful intermediate step for iterating on shared files - as we could temporarily put some changes in the post-sync hook while we iterate on them, before abstracting the changes back into the common location.

Closes #561

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
