### PR TITLE
Fix release find-asset action

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -71,11 +71,18 @@ function find_asset() {
   )
 
   if [[ "${release_json}" == "null" ]]; then
+      echo "No matching asset found for pattern: '${pattern}' on repo: '${repo}' and depth: '${depth}'."
+
       if [[ "${strict}" == "true" ]]; then
-        echo "Error: no matching asset found for pattern: '${pattern}' on repo: ${repo} and depth: ${depth}."
+        echo "Strict mode is enabled - exiting with error."
         exit 1
+      else
+        echo "Strict mode is disabled - exiting without error"
+
+        printf "url=%s\n" "${asset_url}"
+        printf "url=" >> "$GITHUB_OUTPUT"
+        exit 0
       fi
-    url=""
   fi
 
   release_version=$(echo "${release_json}" | jq -r '.tag_name')
@@ -88,7 +95,7 @@ function find_asset() {
   asset_count=$(echo "${assets_json}" | jq 'length')
 
   if [[ "${asset_count}" -gt 1 ]]; then
-    echo "Error: expected one asset - found ${asset_count} assets matching pattern: '${pattern}' on ${repo} ${release_version}."
+    echo "Error: expected one asset - found ${asset_count} assets matching pattern: '${pattern}' on repo: '${repo}' version: '${release_version}'."
     echo "${assets_json}" | jq -r '.[] | "- " + (.name)'
     exit 1
   fi
@@ -96,9 +103,10 @@ function find_asset() {
   asset_name=$(echo "${assets_json}" | jq -r '.[0].name')
   asset_url=$(echo "${assets_json}" | jq -r '.[0].url')
 
-  echo "Found asset: '${asset_name}' on ${repo} ${release_version}."
+  echo "Found asset: '${asset_name}' on repo: '${repo}' version: '${release_version}'."
   echo "Asset URL: ${asset_url}"
 
+  printf "url=%s\n" "${asset_url}"
   printf "url=%s\n" "${asset_url}" >> "$GITHUB_OUTPUT"
 }
 


### PR DESCRIPTION
## Summary

This PR fixes some accidentally broken behavior in the `find-asset` action. This script/action should exit without error when no asset is found and 'strict' is set to 'false'.

## Use Cases

When bootstrapping a new repository we need to be able to succeed without any existing releases (and hence no release assets).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
