### PR TITLE
Fix typo in find-asset action

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -79,7 +79,7 @@ function find_asset() {
       else
         echo "Strict mode is disabled - exiting without error"
 
-        printf "url=%s\n" "${asset_url}"
+        printf "url="
         printf "url=" >> "$GITHUB_OUTPUT"
         exit 0
       fi


### PR DESCRIPTION
## Summary

This PR fixes a typo in #805 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
