### PR TITLE
dependabot: pick up transitive (indirect) dependencies

### DIFF
--- a/builder/.github/dependabot.yml
+++ b/builder/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  allow:
+  # Allow both direct and indirect updates for all packages
+  - dependency-type: "all"

--- a/implementation/.github/dependabot.yml
+++ b/implementation/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  allow:
+  # Allow both direct and indirect updates for all packages
+  - dependency-type: "all"

--- a/language-family/.github/dependabot.yml
+++ b/language-family/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  allow:
+  # Allow both direct and indirect updates for all packages
+  - dependency-type: "all"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Follow up to #813, add config for Dependabot to pick up transitive go.mod dependencies instead
Tested in Bundler and it worked well:
https://github.com/paketo-buildpacks/bundler/pull/566
https://github.com/paketo-buildpacks/bundler/pull/565
https://github.com/paketo-buildpacks/bundler/pull/564
https://github.com/paketo-buildpacks/bundler/pull/563
https://github.com/paketo-buildpacks/bundler/pull/562
https://github.com/paketo-buildpacks/bundler/pull/561


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
