### PR TITLE
Dependabot config: group patch/minor bumps together

### DIFF
--- a/builder/.github/dependabot.yml
+++ b/builder/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
   allow:
   # Allow both direct and indirect updates for all packages
   - dependency-type: "all"
+  # group all minor and patch dependency updates together
+  groups:
+    go-modules:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"

--- a/implementation/.github/dependabot.yml
+++ b/implementation/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
   allow:
   # Allow both direct and indirect updates for all packages
   - dependency-type: "all"
+  # group all minor and patch dependency updates together
+  groups:
+    go-modules:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"

--- a/language-family/.github/dependabot.yml
+++ b/language-family/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
   allow:
   # Allow both direct and indirect updates for all packages
   - dependency-type: "all"
+  # group all minor and patch dependency updates together
+  groups:
+    go-modules:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

We just introduced transitive dependency bumping via Dependabot but it ss very noisy. To reduce the number of PRs, this change will hopefully  group the patch/minor Dependabot changes together in 1 PR to reduce noise

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
