### PR TITLE
Remove bot approval workflow failure notifications

### DIFF
--- a/builder/.github/workflows/approve-bot-pr.yml
+++ b/builder/.github/workflows/approve-bot-pr.yml
@@ -67,22 +67,3 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-
-  failure:
-    name: Alert on Failure
-    runs-on: ubuntu-22.04
-    needs: [download, approve]
-    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
-    steps:
-    - name: File Failure Alert Issue
-      uses: paketo-buildpacks/github-config/actions/issue/file@main
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        label: "failure:approve-bot-pr"
-        comment_if_exists: true
-        issue_title: "Failure: Approve bot PR workflow"
-        issue_body: |
-          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-        comment_body: |
-          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/approve-bot-pr.yml
+++ b/implementation/.github/workflows/approve-bot-pr.yml
@@ -67,22 +67,3 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-
-  failure:
-    name: Alert on Failure
-    runs-on: ubuntu-22.04
-    needs: [download, approve]
-    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
-    steps:
-    - name: File Failure Alert Issue
-      uses: paketo-buildpacks/github-config/actions/issue/file@main
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        label: "failure:approve-bot-pr"
-        comment_if_exists: true
-        issue_title: "Failure: Approve bot PR workflow"
-        issue_body: |
-          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-        comment_body: |
-          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/approve-bot-pr.yml
+++ b/language-family/.github/workflows/approve-bot-pr.yml
@@ -67,22 +67,3 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-
-  failure:
-    name: Alert on Failure
-    runs-on: ubuntu-22.04
-    needs: [download, approve]
-    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
-    steps:
-    - name: File Failure Alert Issue
-      uses: paketo-buildpacks/github-config/actions/issue/file@main
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        label: "failure:approve-bot-pr"
-        comment_if_exists: true
-        issue_title: "Failure: Approve bot PR workflow"
-        issue_body: |
-          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-        comment_body: |
-          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/stack/.github/workflows/approve-bot-pr.yml
+++ b/stack/.github/workflows/approve-bot-pr.yml
@@ -67,22 +67,3 @@ jobs:
         gh pr merge ${{ needs.download.outputs.pr-number }} --auto --rebase
       env:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-
-  failure:
-    name: Alert on Failure
-    runs-on: ubuntu-22.04
-    needs: [download, approve]
-    if: ${{ always() && needs.download.result == 'failure' || needs.approve.result == 'failure' }}
-    steps:
-    - name: File Failure Alert Issue
-      uses: paketo-buildpacks/github-config/actions/issue/file@main
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repo: ${{ github.repository }}
-        label: "failure:approve-bot-pr"
-        comment_if_exists: true
-        issue_title: "Failure: Approve bot PR workflow"
-        issue_body: |
-          Approve bot PR workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
-        comment_body: |
-          Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Remove failure notifications when PR bot approvals fail. We're getting blown up with these notifications, and we came to a consensus that these failures are not necessary to be notified about.

Failures are due to flakiness in PR artifact upload, which cause the zip file we download in the bot approval workflows to be corrupted. This is a well-documented issue on the github-provided upstream Upload Artifact action. We can look into changing how we do automated PR approvals in a separate issue.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
