### PR TITLE
Relax yamllint comment space constraint.

### DIFF
--- a/.github/.yamllint
+++ b/.github/.yamllint
@@ -5,7 +5,6 @@ rules:
   comments:
     require-starting-space: true
     ignore-shebangs: true
-    min-spaces-from-content: 2
   comments-indentation: disable
   document-start: disable
   truthy: disable


### PR DESCRIPTION
## Summary

This PR removes a `yamllint` check requiring a minimum number of spaces between the `#` and the start of the comment.

## Use Cases

We do not find this lint check improves readability and we consistently forget to adhere to it.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
