### PR TITLE
Improve debug output for increment tag action.

### DIFF
--- a/actions/tag/increment-tag/entrypoint
+++ b/actions/tag/increment-tag/entrypoint
@@ -30,6 +30,9 @@ main() {
 
   git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+  printf "current_version=%s\n" "${current_version}" >> "$GITHUB_OUTPUT"
+  printf "allow_head_tagged=%s\n" "${allow_head_tagged}" >> "$GITHUB_OUTPUT"
+
   if [ "${allow_head_tagged}" = "false" ]; then
     if git describe --exact-match --tags HEAD > /dev/null 2>&1; then
       echo "error: HEAD has already been tagged"
@@ -38,14 +41,19 @@ main() {
   fi
 
   if [ -n "${current_version}" ]; then
+    printf "Current version provided: %s\n" "${current_version} - using this as the tag"
     tag="${current_version}"
   else
     if [[ -z "$(git rev-list --tags --max-count=1)" ]]; then
-      echo "There are no previous tags"
+      printf "There are no previous tags - using v0.0.0 as the tag"
       previous="v0.0.0"
     else
       # List all tags of HEAD, sorted in ascending semver order; use the last one
-      previous="$(git tag --sort "version:refname" --points-at "$(git rev-list --tags --max-count=1)" | tail -n 1)"
+      all_previous="$(git tag --sort "version:refname" --merged)"
+      printf "Last 10 previous tags: %s\n" "$(tail -n 10 <<< "${previous}")"
+
+      previous="$(tail -n 1 <<< "${all_previous}")"
+      printf "Previous tag: %s\n" "${previous}"
     fi
     tag="$(printf "%s" "$previous" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')"
   fi


### PR DESCRIPTION
## Summary

This PR improves the debug output for the "increment tag" action.

## Use Cases

We recently ran into an issue where the output tag was not what we expected (see [this failing build](https://github.com/paketo-buildpacks/jammy-base-stack/actions/runs/6536023435/job/17746971933)). This PR improves the debug output so it is easier to reason about which logic path is being taken.

As a side note, I switched to `git tag --merged` (from `git rev-list --tags --max-count=1`) because it allows us to get a list of tags, not just the most recent one. This has the side effect of only listing tags that are in the current branch. This is probably what we want, as we should probably not include tags that aren't on the current branch, but I wanted to call it out explicitly.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
