### PR TITLE
Remove source of non-existent .util/git.sh file

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -12,9 +12,6 @@ source "${PROGDIR}/.util/tools.sh"
 # shellcheck source=SCRIPTDIR/.util/print.sh
 source "${PROGDIR}/.util/print.sh"
 
-# shellcheck source=SCRIPTDIR/.util/git.sh
-source "${PROGDIR}/.util/git.sh"
-
 # shellcheck source=SCRIPTDIR/.util/builders.sh
 source "${PROGDIR}/.util/builders.sh"
 


### PR DESCRIPTION
This source is causing the integration script to fail https://github.com/paketo-buildpacks/go-dist/actions/runs/6799026441/job/18484652568?pr=666


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
