### PR TITLE
Reset-draft action: add optional version flag

### DIFF
--- a/actions/release/reset-draft/action.yml
+++ b/actions/release/reset-draft/action.yml
@@ -4,7 +4,9 @@ description: |
   This action can be used to reset a repository to a state where there are no
   draft releases.
   - If there is a draft release on the target repository, it will be deleted
+    - If a version is passed in, and there is a matching draft release on the target repository, it will be deleted
   - If there is NO draft release, this action is a no op.
+    - If a version line is passed in, and there is NO matching draft release on the target repository, this action is a no op
 
 inputs:
   repo:
@@ -13,6 +15,9 @@ inputs:
   token:
     description: 'Github Access Token used to make the request'
     required: true
+  version:
+    description: 'Optional specific release version to reset'
+    required: false
 
 outputs:
   current_version:
@@ -26,3 +31,5 @@ runs:
   - ${{ inputs.repo }}
   - "--token"
   - ${{ inputs.token }}
+  - "--version"
+  - ${{ inputs.version }}

--- a/actions/release/reset-draft/entrypoint/main.go
+++ b/actions/release/reset-draft/entrypoint/main.go
@@ -15,11 +15,13 @@ func main() {
 		Endpoint string
 		Repo     string
 		Token    string
+		Version  string
 	}
 
 	flag.StringVar(&config.Endpoint, "endpoint", "https://api.github.com", "Specifies endpoint for sending requests")
 	flag.StringVar(&config.Repo, "repo", "", "Specifies repo for sending requests")
 	flag.StringVar(&config.Token, "token", "", "Github Authorization Token")
+	flag.StringVar(&config.Version, "version", "", "Optional specific release version to reset")
 	flag.Parse()
 
 	if config.Repo == "" {
@@ -69,6 +71,27 @@ func main() {
 		return
 	}
 
+	releaseToDelete := releases[0]
+
+	// If version is passed in, look for matching draft
+	if config.Version != "" {
+		found := false
+		for _, r := range releases {
+			if r.TagName == config.Version && r.Draft {
+				fmt.Printf("Matching draft version %s found\n", config.Version)
+
+				releaseToDelete = r
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			fmt.Printf("No releases matching version %s found, exiting.\n", config.Version)
+			return
+		}
+	}
+
 	if !releases[0].Draft {
 		fmt.Println("Latest release is published, exiting.")
 		return
@@ -76,7 +99,7 @@ func main() {
 
 	fmt.Println("Latest release is draft, deleting.")
 
-	req, err = http.NewRequest("DELETE", fmt.Sprintf("%s/repos/%s/releases/%d", config.Endpoint, config.Repo, releases[0].ID), nil)
+	req, err = http.NewRequest("DELETE", fmt.Sprintf("%s/repos/%s/releases/%d", config.Endpoint, config.Repo, releaseToDelete.ID), nil)
 	if err != nil {
 		fail(err)
 	}
@@ -102,7 +125,7 @@ func main() {
 		fail(err)
 	}
 	defer file.Close()
-	fmt.Fprintf(file, "current_version=%s\n", releases[0].TagName)
+	fmt.Fprintf(file, "current_version=%s\n", releaseToDelete.TagName)
 
 	fmt.Println("Success!")
 }

--- a/actions/release/reset-draft/entrypoint/main_test.go
+++ b/actions/release/reset-draft/entrypoint/main_test.go
@@ -57,7 +57,13 @@ func TestEntrypoint(t *testing.T) {
 					fmt.Fprintln(w, `[
 						{
 							"draft": false,
-							"id": 2
+							"id": 2,
+							"tag_name": "random-version"
+						},
+						{
+							"draft": false,
+							"id": 3,
+							"tag_name": "1.2.3"
 						}
 					]`)
 
@@ -67,6 +73,11 @@ func TestEntrypoint(t *testing.T) {
 							"draft": true,
 							"id": 2,
 							"tag_name": "some-version"
+						},
+						{
+							"draft": true,
+							"id": 3,
+							"tag_name": "1.2.3"
 						}
 					]`)
 
@@ -82,6 +93,11 @@ func TestEntrypoint(t *testing.T) {
 					fmt.Fprintln(w, `[]`)
 
 				case "/repos/some-org/draft-repo/releases/2":
+					if req.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusNoContent)
+					}
+
+				case "/repos/some-org/draft-repo/releases/3":
 					if req.Method == http.MethodDelete {
 						w.WriteHeader(http.StatusNoContent)
 					}
@@ -121,6 +137,75 @@ func TestEntrypoint(t *testing.T) {
 			tempDir = t.TempDir()
 		})
 
+		context("when a specific version is passed in", func() {
+			context("when a matching draft release does NOT exist", func() {
+				it("does not change the repo", func() {
+					command := exec.Command(
+						entrypoint,
+						"--endpoint", api.URL,
+						"--repo", "some-org/published-repo",
+						"--token", "some-github-token",
+						"--version", "1.2.3",
+					)
+
+					buffer := gbytes.NewBuffer()
+
+					session, err := gexec.Start(command, buffer, buffer)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(session).Should(gexec.Exit(0), func() string { return fmt.Sprintf("output -> \n%s\n", buffer.Contents()) })
+
+					Expect(requests).To(HaveLen(1))
+					Expect(requests[0].Method).To(Equal("GET"))
+					Expect(requests[0].URL.Path).To(Equal("/repos/some-org/published-repo/releases"))
+
+					Expect(buffer).To(gbytes.Say(`Fetching latest releases`))
+					Expect(buffer).To(gbytes.Say(`  Repository: some-org/published-repo`))
+					Expect(buffer).To(gbytes.Say(`No releases matching version 1.2.3 found, exiting.`))
+				})
+			})
+
+			context("when a matching draft release does exists", func() {
+				it("deletes the draft release and outputs its version", func() {
+					command := exec.Command(
+						entrypoint,
+						"--endpoint", api.URL,
+						"--repo", "some-org/draft-repo",
+						"--token", "some-github-token",
+						"--version", "1.2.3",
+					)
+					command.Env = []string{
+						fmt.Sprintf("GITHUB_OUTPUT=%s", filepath.Join(tempDir, "github-output")),
+						fmt.Sprintf("GITHUB_STATE=%s", filepath.Join(tempDir, "github-state")),
+					}
+
+					buffer := gbytes.NewBuffer()
+
+					session, err := gexec.Start(command, buffer, buffer)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(session).Should(gexec.Exit(0), func() string { return fmt.Sprintf("output -> \n%s\n", buffer.Contents()) })
+
+					Expect(requests).To(HaveLen(2))
+					Expect(requests[0].Method).To(Equal("GET"))
+					Expect(requests[0].URL.Path).To(Equal("/repos/some-org/draft-repo/releases"))
+					Expect(requests[1].Method).To(Equal("DELETE"))
+					Expect(requests[1].URL.Path).To(Equal("/repos/some-org/draft-repo/releases/3"))
+
+					Expect(buffer).To(gbytes.Say(`Fetching latest releases`))
+					Expect(buffer).To(gbytes.Say(`  Repository: some-org/draft-repo`))
+					Expect(buffer).To(gbytes.Say(`Matching draft version 1.2.3 found`))
+					Expect(buffer).To(gbytes.Say(`Latest release is draft, deleting.`))
+					Expect(buffer).To(gbytes.Say(`Success`))
+
+					data, err := os.ReadFile(filepath.Join(tempDir, "github-output"))
+					Expect(err).NotTo(HaveOccurred())
+					outputs := strings.Split(string(data), "\n")
+					Expect(outputs).To(ContainElements("current_version=1.2.3"))
+				})
+			})
+		})
+
 		context("when a draft release does NOT exists", func() {
 			it("does not change the repo", func() {
 				command := exec.Command(
@@ -143,7 +228,6 @@ func TestEntrypoint(t *testing.T) {
 
 				Expect(buffer).To(gbytes.Say(`Fetching latest releases`))
 				Expect(buffer).To(gbytes.Say(`  Repository: some-org/published-repo`))
-				Expect(buffer).To(gbytes.Say(`Latest release is published, exiting.`))
 			})
 		})
 
@@ -363,6 +447,9 @@ func TestEntrypoint(t *testing.T) {
 					Expect(buffer).To(gbytes.Say(`500 Internal Server Error`))
 					Expect(buffer).To(gbytes.Say(`{"error": "server-error"}`))
 				})
+			})
+			context.Focus("when a specific version is passed in", func() {
+
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds optional `--version` flag to the reset draft release action. 
If a tag version is provided, the action will reset a draft release matching the version and no-op exit if no match is found
If no tag version is provided, the action will proceed as usual, deleting the latest draft release if one exists 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
