### PR TITLE
yamllint config: relax indentation consistency

### DIFF
--- a/.github/.yamllint
+++ b/.github/.yamllint
@@ -11,7 +11,7 @@ rules:
   line-length: disable
   indentation:
     spaces: consistent
-    indent-sequences: consistent
+    indent-sequences: whatever
     check-multi-line-strings: false
   brackets:
     max-spaces-inside: -1


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Formatting a workflow with `yq` produces YAML blocks in some cases that cause linting failures when `indent-sequences: consistent` is set in the configuration. I think we should allow valid yq-formatted YAML to pass out linter checks so various tools aren't at odds

Example: ` yq implementation/.github/dependabot.yml` produces YAML that currently FAILs linting with:
```
.github/dependabot.yml
  10:5      error    wrong indentation: expected 2 but found 4  (indentation)
  15:9      error    wrong indentation: expected 6 but found 8  (indentation)
  17:9      error    wrong indentation: expected 6 but found 8  (indentation)
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
