### PR TITLE
Include the post-hook sync script in the list of synced files.

### DIFF
--- a/actions/sync/entrypoint
+++ b/actions/sync/entrypoint
@@ -51,13 +51,6 @@ function main() {
       )
     fi
 
-    if [[ -f "${dest}/.sync-post-hook" ]]; then
-      args+=(
-        --exclude=".sync-post-hook"
-        --exclude-from="${dest}/.sync-post-hook"
-      )
-    fi
-
     bash -c "rsync ${args[*]}"
 
     echo


### PR DESCRIPTION
## Summary

This PR adds the `sync-post-hook` file to the included list of files that are synced from the shared config to downstream repositories. Specifically, it removes the exception where it _was not_ included, and therefore the `sync-post-hook` file is now treated the same as any other file.

## Use Cases

This change allows us to put common post-hook scripts in the shared config and propagate them to down repositories like any other file. If a repo wants a specific post-hook script that differs from the shared one (or one where the is none in the shared config repo), it can be added to the `.syncignore` file like any other ignored file.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
