### PR TITLE
Adding option for enabling experimental options in pack

### DIFF
--- a/builder/.github/workflows/push-image.yml
+++ b/builder/.github/workflows/push-image.yml
@@ -30,6 +30,12 @@ jobs:
       with:
         pack-version: ${{ steps.pack-version.outputs.version }}
 
+    - name: Enable Experimental Pack Features
+      run: |
+        if [ -f "scripts/options.json" ] && jq -e -r .pack_config_enable_experimental "scripts/options.json" > /dev/null; then
+          pack config experimental true
+        fi
+
     - name: Create Builder Image
       run: |
         pack builder create builder --config builder.toml

--- a/builder/scripts/.util/tools.sh
+++ b/builder/scripts/.util/tools.sh
@@ -135,6 +135,13 @@ function util::tools::pack::install() {
 
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    local pack_config_enable_experimental
+    if [ -f "$(dirname "${BASH_SOURCE[0]}")/../options.json" ]; then
+      pack_config_enable_experimental="$(jq -r .pack_config_enable_experimental "$(dirname "${BASH_SOURCE[0]}")/../options.json")"
+    else
+      pack_config_enable_experimental="false"
+    fi
+
     tmp_location="/tmp/pack.tgz"
     curl_args=(
       "--fail"
@@ -157,6 +164,10 @@ function util::tools::pack::install() {
 
     tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
+
+    if [[ "${pack_config_enable_experimental}" == "true" ]]; then
+      "${dir}"/pack config experimental true
+    fi
 
     rm "${tmp_location}"
   else

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -135,6 +135,13 @@ function util::tools::pack::install() {
 
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    local pack_config_enable_experimental
+    if [ -f "$(dirname "${BASH_SOURCE[0]}")/../options.json" ]; then
+      pack_config_enable_experimental="$(jq -r .pack_config_enable_experimental "$(dirname "${BASH_SOURCE[0]}")/../options.json")"
+    else
+      pack_config_enable_experimental="false"
+    fi
+
     tmp_location="/tmp/pack.tgz"
     curl_args=(
       "--fail"
@@ -157,6 +164,10 @@ function util::tools::pack::install() {
 
     tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
+
+    if [[ "${pack_config_enable_experimental}" == "true" ]]; then
+      "${dir}"/pack config experimental true
+    fi
 
     rm "${tmp_location}"
   else

--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -135,6 +135,13 @@ function util::tools::pack::install() {
 
     version="$(jq -r .pack "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
 
+    local pack_config_enable_experimental
+    if [ -f "$(dirname "${BASH_SOURCE[0]}")/../options.json" ]; then
+      pack_config_enable_experimental="$(jq -r .pack_config_enable_experimental "$(dirname "${BASH_SOURCE[0]}")/../options.json")"
+    else
+      pack_config_enable_experimental="false"
+    fi
+
     tmp_location="/tmp/pack.tgz"
     curl_args=(
       "--fail"
@@ -157,6 +164,10 @@ function util::tools::pack::install() {
 
     tar xzf "${tmp_location}" -C "${dir}"
     chmod +x "${dir}/pack"
+
+    if [[ "${pack_config_enable_experimental}" == "true" ]]; then
+      "${dir}"/pack config experimental true
+    fi
 
     rm "${tmp_location}"
   else


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds enables the experimental feature during the installation of pack. This is possible by looking at the `options.json` file under the `./scripts` directory. If someone wants to enable experimental features in pack, needs to create an `options.json` file with below content
```json
{
  "pack_config_enable_experimental": true
}
```

In case there is no `options.json` file available, it fallbacks to the old behavior which is not enabling experimental features of pack.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This PR gives the option to specify if the script should enable or not the experimental features of `pack`. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
