### PR TITLE
Dependabot: exclude problematic dependencies from group PRs

### DIFF
--- a/implementation/.github/dependabot.yml
+++ b/implementation/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
       update-types:
       - "minor"
       - "patch"
+      exclude-patterns:
+      - "github.com/anchore/stereoscope"
+      - "github.com/testcontainers/testcontainers-go"
+      - "github.com/docker/docker"
+      - "github.com/containerd/containerd"

--- a/language-family/.github/dependabot.yml
+++ b/language-family/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
       update-types:
       - "minor"
       - "patch"
+      exclude-patterns:
+      - "github.com/anchore/stereoscope"
+      - "github.com/testcontainers/testcontainers-go"
+      - "github.com/docker/docker"
+      - "github.com/containerd/containerd"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds a few of the frequently problematic go modules to an exclude-pattern, meaning they won't be updated in Dependabot group PRs, but instead will go into their own PRs which will help unblock us updating other updates in the instance of incompatibilities

Followed these docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-1

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

