### PR TITLE
Fixing wrong logging on modified stack packages

### DIFF
--- a/actions/stack/diff-package-receipts/entrypoint/main.go
+++ b/actions/stack/diff-package-receipts/entrypoint/main.go
@@ -133,7 +133,7 @@ func main() {
 	}
 	fmt.Println("Modified packages:")
 	for _, pkg := range modified {
-		fmt.Printf("%[1]s %s (PURL: %s) => %[1]s %s (PURL: %s)\n",
+		fmt.Printf("%[1]s %[2]s (PURL: %[3]s) => %[1]s %[4]s (PURL: %[5]s)\n",
 			pkg.Name,
 			pkg.PreviousVersion,
 			pkg.PreviousPURL,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes the logging on the modified packages of the stack.
Instead of this, which is the wrong version, as the current and the previous are the same
```
linux-libc-dev 5.15.0-105.115 (PURL: pkg:deb/ubuntu/linux-libc-dev@5.15.0-105.115?arch=amd64&upstream=linux&distro=ubuntu-22.04) => linux-libc-dev 5.15.0-105.115 (PURL: pkg:deb/ubuntu/linux-libc-dev@5.15.0-105.115?arch=amd64&upstream=linux&distro=ubuntu-22.04)
```
 
it fixes it to this where the current and the previous version are different
```
linux-libc-dev 5.15.0-105.115 (PURL: pkg:deb/ubuntu/linux-libc-dev@5.15.0-105.115?arch=amd64&upstream=linux&distro=ubuntu-22.04) => linux-libc-dev 5.15.0-106.116 (PURL: pkg:deb/ubuntu/linux-libc-dev@5.15.0-106.116?arch=amd64&upstream=linux&distro=ubuntu-22.04)
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
