### PR TITLE
Add workflow to update go mod version.

### DIFF
--- a/actions/update-go-mod-version/Dockerfile
+++ b/actions/update-go-mod-version/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+
+RUN apk add \
+    bash \
+    && rm -rf /var/cache/apk/*
+
+COPY entrypoint /entrypoint
+ENTRYPOINT ["/entrypoint"]

--- a/actions/update-go-mod-version/action.yml
+++ b/actions/update-go-mod-version/action.yml
@@ -1,0 +1,15 @@
+name: "Update Go Mod Version"
+description: |
+  Updates the versions of go and the go toolchain in a go.mod file
+
+inputs:
+  toolchain-version:
+    description: 'Version of the toolchain to write'
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+  - "--toolchain-version"
+  - "${{ inputs.toolchain-version }}"

--- a/actions/update-go-mod-version/entrypoint
+++ b/actions/update-go-mod-version/entrypoint
@@ -1,0 +1,64 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+function main() {
+  local min_go_version toolchain_version
+  min_go_version="1.21" # 1.21 is the minimum to use the toolchain directive in go.mod
+  toolchain_version=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --toolchain-version)
+        toolchain_version="${2}"
+        shift 2
+        ;;
+
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
+
+      *)
+        echo "Unknown argument" "$@"
+        exit 1
+    esac
+  done
+  
+  if [[ -z "${toolchain_version}" ]]; then
+    echo "Must provide toolchain version"
+    exit 1
+  fi
+
+  found_go_version="$(grep -E 'go ([0-9]+\.[0-9]+)' < go.mod | sed 's/go //g')"
+
+  if lt "${found_go_version}" "${min_go_version}"; then
+    echo "Updating go version to the minimum required version '${min_go_version}' (was '${found_go_version}')"
+    sed -i "s/go ${found_go_version}/go ${min_go_version}/g" go.mod
+    found_go_version="${min_go_version}"
+  else
+    echo "not updating go version as current version (${found_go_version}) is >= minimum required version (${min_go_version})"
+  fi
+
+  echo "setting toolchain to: '${toolchain_version}'"
+  if grep -qE 'toolchain go(.*)' < go.mod; then 
+    sed -i "s/toolchain go.*/toolchain go${toolchain_version}/g" go.mod    
+  else
+    # Write the toolchain directive two lines below the go version
+    sed -i "/go ${found_go_version}/r"<(printf "\ntoolchain go%s\n" "${toolchain_version}") go.mod
+  fi
+}
+
+# returns $1 <= $2
+function lte() {
+    printf '%s\n' "$1" "$2" | sort -CV
+}
+
+# returns $1 < $2
+function lt() {
+  ! lte "$2" "$1"
+}
+
+main "${@:-}"
+

--- a/builder/.github/workflows/update-go-mod-version.yml
+++ b/builder/.github/workflows/update-go-mod-version.yml
@@ -1,0 +1,78 @@
+name: Update Go version
+
+on:
+  schedule:
+    - cron: '53 5 * * MON'  # every monday at 5:53 UTC
+  workflow_dispatch:
+
+concurrency: update-go
+
+jobs:
+  update-go:
+    name: Update go toolchain in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Checkout PR Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Get current go toolchain version
+        id: current-go-version
+        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        with:
+          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+      - name: Show changes
+        run: |
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Updating go mod version"
+          pathspec: "."
+          keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+          key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Updates go mod version"
+          branch: automation/go-mod-update/update-main
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-go]
+    if: ${{ always() && needs.update-go.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-go-version"
+          comment_if_exists: true
+          issue_title: "Failure: Update Go Mod Version workflow"
+          issue_body: |
+            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/update-go-mod-version.yml
+++ b/builder/.github/workflows/update-go-mod-version.yml
@@ -28,8 +28,23 @@ jobs:
         uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
-      - name: Show changes
+      - name: Go mod tidy
         run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          echo "Before running go mod tidy"
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+
+          echo "Running go mod tidy"
+          go mod tidy
+
+          echo "After running go mod tidy"
           echo "head -n10 go.mod "
           head -n10 go.mod
 
@@ -39,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updating go mod version"
+          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -55,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod version"
+          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:
@@ -73,6 +88,6 @@ jobs:
           comment_if_exists: true
           issue_title: "Failure: Update Go Mod Version workflow"
           issue_body: |
-            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Update Go Mod Version workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/builder/.github/workflows/update-go-mod-version.yml
+++ b/builder/.github/workflows/update-go-mod-version.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 'stable'
       - name: Get current go toolchain version
         id: current-go-version
-        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy

--- a/implementation/.github/workflows/update-go-mod-version.yml
+++ b/implementation/.github/workflows/update-go-mod-version.yml
@@ -28,8 +28,23 @@ jobs:
         uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
-      - name: Show changes
+      - name: Go mod tidy
         run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          echo "Before running go mod tidy"
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+
+          echo "Running go mod tidy"
+          go mod tidy
+
+          echo "After running go mod tidy"
           echo "head -n10 go.mod "
           head -n10 go.mod
 
@@ -39,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updating go mod version"
+          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -55,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod version"
+          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:
@@ -73,6 +88,6 @@ jobs:
           comment_if_exists: true
           issue_title: "Failure: Update Go Mod Version workflow"
           issue_body: |
-            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Update Go Mod Version workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/update-go-mod-version.yml
+++ b/implementation/.github/workflows/update-go-mod-version.yml
@@ -1,0 +1,78 @@
+name: Update Go version
+
+on:
+  schedule:
+    - cron: '48 4 * * MON'  # every monday at 4:48 UTC
+  workflow_dispatch:
+
+concurrency: update-go
+
+jobs:
+  update-go:
+    name: Update go toolchain in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Checkout PR Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Get current go toolchain version
+        id: current-go-version
+        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        with:
+          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+      - name: Show changes
+        run: |
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Updating go mod version"
+          pathspec: "."
+          keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+          key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Updates go mod version"
+          branch: automation/go-mod-update/update-main
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-go]
+    if: ${{ always() && needs.update-go.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-go-version"
+          comment_if_exists: true
+          issue_title: "Failure: Update Go Mod Version workflow"
+          issue_body: |
+            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/implementation/.github/workflows/update-go-mod-version.yml
+++ b/implementation/.github/workflows/update-go-mod-version.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 'stable'
       - name: Get current go toolchain version
         id: current-go-version
-        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy

--- a/language-family/.github/workflows/update-go-mod-version.yml
+++ b/language-family/.github/workflows/update-go-mod-version.yml
@@ -1,0 +1,78 @@
+name: Update Go version
+
+on:
+  schedule:
+    - cron: '13 4 * * MON'  # every monday at 4:13 UTC
+  workflow_dispatch:
+
+concurrency: update-go
+
+jobs:
+  update-go:
+    name: Update go toolchain in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Checkout PR Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Get current go toolchain version
+        id: current-go-version
+        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        with:
+          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+      - name: Show changes
+        run: |
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Updating go mod version"
+          pathspec: "."
+          keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+          key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Updates go mod version"
+          branch: automation/go-mod-update/update-main
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-go]
+    if: ${{ always() && needs.update-go.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-go-version"
+          comment_if_exists: true
+          issue_title: "Failure: Update Go Mod Version workflow"
+          issue_body: |
+            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/update-go-mod-version.yml
+++ b/language-family/.github/workflows/update-go-mod-version.yml
@@ -28,8 +28,23 @@ jobs:
         uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
-      - name: Show changes
+      - name: Go mod tidy
         run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          echo "Before running go mod tidy"
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+
+          echo "Running go mod tidy"
+          go mod tidy
+
+          echo "After running go mod tidy"
           echo "head -n10 go.mod "
           head -n10 go.mod
 
@@ -39,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updating go mod version"
+          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -55,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod version"
+          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:
@@ -73,6 +88,6 @@ jobs:
           comment_if_exists: true
           issue_title: "Failure: Update Go Mod Version workflow"
           issue_body: |
-            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Update Go Mod Version workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/language-family/.github/workflows/update-go-mod-version.yml
+++ b/language-family/.github/workflows/update-go-mod-version.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 'stable'
       - name: Get current go toolchain version
         id: current-go-version
-        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy

--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -28,8 +28,23 @@ jobs:
         uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
-      - name: Show changes
+      - name: Go mod tidy
         run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          echo "Before running go mod tidy"
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+
+          echo "Running go mod tidy"
+          go mod tidy
+
+          echo "After running go mod tidy"
           echo "head -n10 go.mod "
           head -n10 go.mod
 
@@ -39,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updating go mod version"
+          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -55,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod version"
+          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:
@@ -73,6 +88,6 @@ jobs:
           comment_if_exists: true
           issue_title: "Failure: Update Go Mod Version workflow"
           issue_body: |
-            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Update Go Mod Version workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -1,0 +1,78 @@
+name: Update Go version
+
+on:
+  schedule:
+    - cron: '19 3 * * MON'  # every monday at 3:19 UTC
+  workflow_dispatch:
+
+concurrency: update-go
+
+jobs:
+  update-go:
+    name: Update go toolchain in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Checkout PR Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Get current go toolchain version
+        id: current-go-version
+        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        with:
+          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+      - name: Show changes
+        run: |
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Updating go mod version"
+          pathspec: "."
+          keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+          key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Updates go mod version"
+          branch: automation/go-mod-update/update-main
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-go]
+    if: ${{ always() && needs.update-go.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-go-version"
+          comment_if_exists: true
+          issue_title: "Failure: Update Go Mod Version workflow"
+          issue_body: |
+            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 'stable'
       - name: Get current go toolchain version
         id: current-go-version
-        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy

--- a/stack/.github/workflows/update-go-mod-version.yml
+++ b/stack/.github/workflows/update-go-mod-version.yml
@@ -28,8 +28,23 @@ jobs:
         uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
-      - name: Show changes
+      - name: Go mod tidy
         run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          echo "Before running go mod tidy"
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+
+          echo "Running go mod tidy"
+          go mod tidy
+
+          echo "After running go mod tidy"
           echo "head -n10 go.mod "
           head -n10 go.mod
 
@@ -39,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updating go mod version"
+          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -55,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod version"
+          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:
@@ -73,6 +88,6 @@ jobs:
           comment_if_exists: true
           issue_title: "Failure: Update Go Mod Version workflow"
           issue_body: |
-            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+            Update Go Mod Version workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
           comment_body: |
             Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/stack/.github/workflows/update-go-mod-version.yml
+++ b/stack/.github/workflows/update-go-mod-version.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 'stable'
       - name: Get current go toolchain version
         id: current-go-version
-        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
           toolchain-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy

--- a/stack/.github/workflows/update-go-mod-version.yml
+++ b/stack/.github/workflows/update-go-mod-version.yml
@@ -1,0 +1,78 @@
+name: Update Go version
+
+on:
+  schedule:
+    - cron: '21 4 * * MON'  # every monday at 4:21 UTC
+  workflow_dispatch:
+
+concurrency: update-go
+
+jobs:
+  update-go:
+    name: Update go toolchain in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Checkout PR Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Get current go toolchain version
+        id: current-go-version
+        uses: pivotal-cf/tanzu-cnb-github-config/actions/update-go-mod-version@main
+        with:
+          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+      - name: Show changes
+        run: |
+          echo "head -n10 go.mod "
+          head -n10 go.mod
+
+          echo "git diff"
+          git diff
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Updating go mod version"
+          pathspec: "."
+          keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+          key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/go-mod-update/update-main
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Updates go mod version"
+          branch: automation/go-mod-update/update-main
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update-go]
+    if: ${{ always() && needs.update-go.result == 'failure' }}
+    steps:
+      - name: File Failure Alert Issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          label: "failure:update-go-version"
+          comment_if_exists: true
+          issue_title: "Failure: Update Go Mod Version workflow"
+          issue_body: |
+            Update GitHub config workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+          comment_body: |
+            Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
## Summary

This PR adds a workflow to update the version of `go` and the `toolchain` in `go.mod`. It also adds the associated failure labels for when this job fails.

See https://github.com/orgs/paketo-buildpacks/discussions/283

## Use cases

We want to keep the `toolchain go1.X.Y` line up to date with the latest version of go available, as that is the actual version of the `go` toolchain that will be used to build the module. If this line is present, `go` will guarantee to build with this version of `go` toolchain, regardless of what version is provided in CI. Essentially this line locks down the version of go used to build a module at a specific point in time. By keeping it up to date, we guarantee that we're always building with the latest version of `go`.

One caveat is that this `toolchain` line _requires_ a minimum version of the `go 1.x` line in the `go.mod` - specifically it requires `go 1.21` or greater. So this workflow will also bump that version if it is lower than `1.21`. It will ignore the line if it is greater than or equal to `go 1.21`.

I think running this job once per week is sufficient. Go doesn't release patch versions that frequently, and we don't release buildpacks more frequently than weekly. We can always invoke it directly with the `workflow_dispatch` in case of a critical CVE fix between scheduled runs.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
