### PR TITLE
Fix go mod update workflow

### DIFF
--- a/actions/update-go-mod-version/entrypoint
+++ b/actions/update-go-mod-version/entrypoint
@@ -52,7 +52,7 @@ function main() {
 
 # returns $1 <= $2
 function lte() {
-    printf '%s\n' "$1" "$2" | sort -CV
+  [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]]
 }
 
 # returns $1 < $2


### PR DESCRIPTION
## Summary

This PR fixes a bug in in the action that updates the version of go.

Specifically:

The `sort -C/--check=silent` option only exists on GNU sort, but the action runs busybox sort (as it is on alpine). There is no equivalent for the `-C` for the version of `sort` we are using, so we have to implement something else.

I've validated this works against real `go.mod` files.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
