### PR TITLE
Add exponential backoff to open-pr action.

### DIFF
--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -80,7 +80,7 @@ function main() {
 #
 # based on: https://stackoverflow.com/questions/8350942/how-to-re-run-the-curl-command-automatically-when-the-error-occurs/8351489#8351489
 function with_backoff {
- local max_attempts=8 # about two minutes 
+  local max_attempts=8 # about two minutes 
   local timeout=1 # seconds between retries
   local attempt=1
   local exitCode=0

--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -63,12 +63,50 @@ function main() {
 
   git config --global --add safe.directory "${GITHUB_WORKSPACE}"
   pushd "${GITHUB_WORKSPACE}" > /dev/null || true
-    gh pr create \
+    with_backoff gh pr create \
       --title "${title}" \
       --body "${body}" \
       --base "${base}" \
       --label "${label}"
   popd > /dev/null || true
+}
+
+# Retries a command a configurable number of times with backoff.
+#
+# Successive backoffs double the timeout.
+#
+# The rough total time is given by 2^(n-1)*t where n is the maximum number of attempts and t is the timeout between retries
+# At n=8 and t=1 second the total time is about 2^7*1 = 128 seconds, or about two minutes.
+#
+# based on: https://stackoverflow.com/questions/8350942/how-to-re-run-the-curl-command-automatically-when-the-error-occurs/8351489#8351489
+function with_backoff {
+ local max_attempts=8 # about two minutes 
+  local timeout=1 # seconds between retries
+  local attempt=1
+  local exitCode=0
+
+  while (( attempt < max_attempts ))
+  do
+    echo "running command: ${*}"
+    if "$@"
+    then
+      return 0
+    else
+      exitCode=$?
+    fi
+
+    echo "Failed to run command. Retrying in $timeout seconds..." 1>&2
+    sleep $timeout
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "Failed after ${attempt} attempts" 1>&2
+  fi
+
+  return $exitCode
 }
 
 main "${@:-}"


### PR DESCRIPTION
- we often see this action fail with graphQL errors if we try to open too many PRs in a short amount of time.

I've validated this logic works locally:

```
❯ docker run --rm -it -e GITHUB_WORKSPACE=. -e GITHUB_REPOSITORY="<some-repo>" gha-pr-tmp --token "$(gh auth token)" --branch 'tmp' --title 'whatever' --body '' --base 'missing-branch' --label 'some-label'


A new release of gh is available: 1.7.0 → v2.50.0
https://github.com/cli/cli/releases/tag/v2.50.0

Opening Pull Request
running command: gh pr create --title test PR --body test pr body --base bad --label some-label
fatal: not a git repository (or any of the parent directories): .git
/usr/bin/git: exit status 128
Failed to run command. Retrying in 1 seconds...
...
/usr/bin/git: exit status 128
Failed to run command. Retrying in 32 seconds...
fatal: not a git repository (or any of the parent directories): .git
/usr/bin/git: exit status 128
Failed to run command. Retrying in 64 seconds...
Failed after 8 attempts
```