### PR TITLE
allow checkout force pr

### DIFF
--- a/actions/pull-request/checkout-branch/action.yml
+++ b/actions/pull-request/checkout-branch/action.yml
@@ -1,13 +1,18 @@
 name: 'Checkout branch'
 
 description: |
-  Checkout a branch. If the branch doesn't exist on the
-  remote, create and check it out.
+  Checkout a branch at a specified start point.
+  If no start point is provided, then checkout the upstream equivalent of the provided branch.
+  If the branch doesn't exist on the upstream, create it at the HEAD.
 
 inputs:
   branch:
     description: 'Name of the branch to checkout'
     required: true
+  start-point:
+    description: 'Reference to checkout the branch at. If not provided, will default to the upstream if it exists or HEAD if there is no equivalent upstream branch.'
+    required: false
+    default: ""
 
 runs:
   using: 'docker'
@@ -15,3 +20,5 @@ runs:
   args:
   - "--branch"
   - ${{ inputs.branch }}
+  - "--start-point"
+  - ${{ inputs.start-point }}

--- a/actions/pull-request/checkout-branch/entrypoint
+++ b/actions/pull-request/checkout-branch/entrypoint
@@ -3,11 +3,16 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 function main() {
-  local branch
+  local branch start_point
   while [ "${#}" != 0 ]; do
     case "${1}" in
       --branch)
         branch="${2}"
+        shift 2
+        ;;
+
+      --start-point)
+        start_point="${2}"
         shift 2
         ;;
 
@@ -23,12 +28,17 @@ function main() {
 
   git config --global --add safe.directory "${GITHUB_WORKSPACE}"
   git fetch origin
-  if git branch -a | grep "${branch}"; then
-    git checkout -b "${branch}" "origin/${branch}"
-    git pull -r
-    chmod -R a+w .
+
+  if [[ -n "${start_point}" ]]; then
+    git checkout -b "${branch}" "${start_point}"
   else
-    git checkout -b "${branch}"
+    if git branch -a | grep "${branch}"; then
+      git checkout -b "${branch}" "origin/${branch}"
+      git pull -r
+      chmod -R a+w .
+    else
+      git checkout -b "${branch}"
+    fi
   fi
 }
 

--- a/actions/pull-request/push-branch/action.yml
+++ b/actions/pull-request/push-branch/action.yml
@@ -7,6 +7,10 @@ inputs:
   branch:
     description: 'Name of the branch to push'
     required: true
+  force:
+    description: 'Push using --force-with-lease'
+    required: false
+    default: ""
 
 runs:
   using: 'docker'
@@ -14,3 +18,5 @@ runs:
   args:
   - "--branch"
   - ${{ inputs.branch }}
+  - "--force"
+  - ${{ inputs.force }}

--- a/actions/pull-request/push-branch/entrypoint
+++ b/actions/pull-request/push-branch/entrypoint
@@ -3,11 +3,16 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 function main() {
-  local branch
+  local branch force
   while [ "${#}" != 0 ]; do
     case "${1}" in
       --branch)
         branch="${2}"
+        shift 2
+        ;;
+
+      --force)
+        force="${2}"
         shift 2
         ;;
 
@@ -22,7 +27,12 @@ function main() {
   done
 
   git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-  git push origin "${branch}"
+
+  if [[ "${force}" == "true" ]]; then
+    git push origin "${branch}" --force-with-lease
+  else
+    git push origin "${branch}"
+  fi
 }
 
 main "${@:-}"


### PR DESCRIPTION
## Summary

This PR adds support for force pushing the branches from a specific location when using the Pull Request branch push action.

## Use cases

This is useful because there are situations where automation checks out a branch but for whatever reason fails to create a PR (or the PR is later closed). This PR allows a workflow to check out the branch at a specific location, regardless of where the upstream is at, and then force push that branch. This would have the forcing function of also opening a new PR for this branch once it is force-pushed.

When used in a github workflow like `sync-github-config` with `start-point: HEAD`, this will have the effect of squashing all outstanding changes into a single commit that is then rebased on top of `HEAD`, and force-pushing this to the upstream location.

When there are no changes to be made, the current behavior is unchanged, because the commit would be empty.

I haven't tested this in a workflow, but I've validated the usage of the `git` commands locally.