### PR TITLE
Conditionally packaging a buildpack or an extension

### DIFF
--- a/implementation/scripts/package.sh
+++ b/implementation/scripts/package.sh
@@ -64,20 +64,25 @@ function main {
 
   tools::install "${token}"
 
-  buildpack::archive "${version}"
-  buildpackage::create "${output}"
+  buildpack_type=buildpack
+  if [ -f "extension.toml" ]; then
+    buildpack_type=extension
+  fi
+
+  buildpack::archive "${version}" "${buildpack_type}"
+  buildpackage::create "${output}" "${buildpack_type}"
 }
 
 function usage() {
   cat <<-USAGE
 package.sh --version <version> [OPTIONS]
 
-Packages the buildpack into a buildpackage .cnb file.
+Packages a buildpack or an extension into a buildpackage .cnb file.
 
 OPTIONS
   --help               -h            prints the command usage
-  --version <version>  -v <version>  specifies the version number to use when packaging the buildpack
-  --output <output>    -o <output>   location to output the packaged buildpackage artifact (default: ${ROOT_DIR}/build/buildpackage.cnb)
+  --version <version>  -v <version>  specifies the version number to use when packaging a buildpack or an extension
+  --output <output>    -o <output>   location to output the packaged buildpackage or extension artifact (default: ${ROOT_DIR}/build/buildpackage.cnb)
   --token <token>                    Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
 USAGE
 }
@@ -114,8 +119,9 @@ function tools::install() {
 function buildpack::archive() {
   local version
   version="${1}"
+  buildpack_type="${2}"
 
-  util::print::title "Packaging buildpack into ${BUILD_DIR}/buildpack.tgz..."
+  util::print::title "Packaging ${buildpack_type} into ${BUILD_DIR}/buildpack.tgz..."
 
   if [[ -f "${ROOT_DIR}/.libbuildpack" ]]; then
     packager \
@@ -125,7 +131,7 @@ function buildpack::archive() {
       "${BUILD_DIR}/buildpack"
   else
     jam pack \
-      --buildpack "${ROOT_DIR}/buildpack.toml" \
+      "--${buildpack_type}" "${ROOT_DIR}/${buildpack_type}.toml"\
       --version "${version}" \
       --output "${BUILD_DIR}/buildpack.tgz"
   fi
@@ -134,13 +140,30 @@ function buildpack::archive() {
 function buildpackage::create() {
   local output
   output="${1}"
+  buildpack_type="${2}"
 
-  util::print::title "Packaging buildpack..."
+  util::print::title "Packaging ${buildpack_type}... ${output}"
 
-  pack \
-    buildpack package "${output}" \
-      --path "${BUILD_DIR}/buildpack.tgz" \
-      --format file
+  if [ "$buildpack_type" == "extension" ]; then
+    cwd=$(pwd)
+    cd ${BUILD_DIR}
+    mkdir cnbdir
+    cd cnbdir
+    cp ../buildpack.tgz .
+    tar -xvf buildpack.tgz
+    rm buildpack.tgz
+
+    pack \
+      extension package "${output}" \
+        --format file
+
+    cd $cwd
+  else
+    pack \
+      buildpack package "${output}" \
+        --path "${BUILD_DIR}/buildpack.tgz" \
+        --format file
+  fi
 }
 
 main "${@:-}"

--- a/implementation/scripts/package.sh
+++ b/implementation/scripts/package.sh
@@ -65,7 +65,7 @@ function main {
   tools::install "${token}"
 
   buildpack_type=buildpack
-  if [ -f "extension.toml" ]; then
+  if [ -f "${ROOT_DIR}/extension.toml" ]; then
     buildpack_type=extension
   fi
 


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR changes the package.sh script to conditionally package a buildpack or an extension according to whether is an extension or a buildpack.

The way this is implemented is to check whether the extension file exists on the directory, otherwise, it fallbacks to the default behavior of packaging a buildpack.

Test results:
* node-engine: https://github.com/pacostas/node-engine/pull/48
* ubi-nodejs-extension: https://github.com/pacostas/ubi-nodejs-extension/pull/67


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
