### PR TITLE
Make auto-label semver action fail if there are no patchfiles

### DIFF
--- a/actions/pull-request/auto-semver-label/check-files-changed.sh
+++ b/actions/pull-request/auto-semver-label/check-files-changed.sh
@@ -77,7 +77,7 @@ function main() {
     if [ "${safe}" -eq "0" ]; then
       echo "Files changed that aren't on the patch allowlist"
       echo "label=" >> "$GITHUB_OUTPUT"
-      exit 0
+      exit 1
     fi
   done < <(gh api /repos/"${repo}"/pulls/"${number}"/files --jq '.[].filename')
 


### PR DESCRIPTION
The function of this task is to check if it can auto-label anything with a semver label and return the label if it can. It is run after a check to see if there are any semver labels already set and if there are not this action will run. I think that it would then follow logically that this action should fail if there are no labels to add meaning the whole check task will fail.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
