### PR TITLE
Limit show receipts

### DIFF
--- a/actions/stack/release-notes/action.yml
+++ b/actions/stack/release-notes/action.yml
@@ -44,6 +44,9 @@ inputs:
   supports_usns:
     description: 'Boolean whether the release notes should support/show USNs'
     required: false
+  receipts_show_limit:
+    description: 'Integer which defines the limit of whether it should show or not the receipts array of each image'
+    required: false
 
 runs:
   using: 'docker'
@@ -73,3 +76,5 @@ runs:
   - "${{ inputs.run_packages_removed_with_force }}"
   - "--supports-usns"
   - "${{ inputs.supports_usns }}"
+  - "--receipts-show-limit"
+  - "${{ inputs.receipts_show_limit }}"

--- a/actions/stack/release-notes/entrypoint/main.go
+++ b/actions/stack/release-notes/entrypoint/main.go
@@ -51,6 +51,7 @@ func main() {
 		RunPackagesRemovedJSON    string
 		PatchedJSON               string
 		SupportsUsns              string
+		ReceiptsShowLimit         string
 	}
 
 	flag.StringVar(&config.BuildImage, "build-image", "", "Registry location of stack build image")
@@ -65,21 +66,23 @@ func main() {
 	flag.StringVar(&config.RunPackagesAddedJSON, "run-added", "", "JSON Array of packages added to run image")
 	flag.StringVar(&config.RunPackagesModifiedJSON, "run-modified", "", "JSON Array of packages modified in run image")
 	flag.StringVar(&config.RunPackagesRemovedJSON, "run-removed", "", "JSON Array of packages removed in run image")
+	flag.StringVar(&config.ReceiptsShowLimit, "receipts-show-limit", "2147483647", "Integer which defines the limit of whether it should show or not the receipts array of each image")
 	flag.Parse()
 
 	var contents struct {
-		PatchedArray   []USN
-		SupportsUsns   bool
-		BuildAdded     []Package
-		BuildModified  []ModifiedPackage
-		BuildRemoved   []Package
-		RunAdded       []Package
-		RunModified    []ModifiedPackage
-		RunRemoved     []Package
-		BuildImage     string
-		RunImage       string
-		BuildCveReport string
-		RunCveReport   string
+		PatchedArray      []USN
+		SupportsUsns      bool
+		BuildAdded        []Package
+		BuildModified     []ModifiedPackage
+		BuildRemoved      []Package
+		RunAdded          []Package
+		RunModified       []ModifiedPackage
+		RunRemoved        []Package
+		BuildImage        string
+		RunImage          string
+		BuildCveReport    string
+		RunCveReport      string
+		ReceiptsShowLimit int
 	}
 
 	err := json.Unmarshal([]byte(fixEmptyArray(config.PatchedJSON)), &contents.PatchedArray)
@@ -144,6 +147,11 @@ func main() {
 
 	contents.BuildImage = config.BuildImage
 	contents.RunImage = config.RunImage
+	contents.ReceiptsShowLimit, err = strconv.Atoi(config.ReceiptsShowLimit)
+
+	if err != nil {
+		log.Fatalf("failed converting receipts show limit string to int: %s", err.Error())
+	}
 
 	t, err := template.New("template.md").Parse(tString)
 	if err != nil {

--- a/actions/stack/release-notes/entrypoint/template.md
+++ b/actions/stack/release-notes/entrypoint/template.md
@@ -22,33 +22,45 @@ No USNs patched in this release.
 
 ## Build Image Package Changes
 ### Added
-{{- if ne (len .BuildAdded) 0 }}
+{{- if and (gt (len .BuildAdded) 0) (lt (len .BuildAdded) .ReceiptsShowLimit) }}
 ```
 {{- range .BuildAdded }}
 {{ .Name }} {{ .Version }} (PURL: {{ .PURL }})
 {{- end }}
+```
+{{- else if and (gt (len .BuildAdded) 0) (gt (len .BuildAdded) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages added.
 {{- end }}
 
 ### Modified
-{{- if ne (len .BuildModified) 0 }}
+{{- if and (gt (len .BuildModified) 0) (lt (len .BuildModified) .ReceiptsShowLimit) }}
 ```
 {{- range .BuildModified }}
 {{ .Name }} {{ .PreviousVersion }} ==> {{ .CurrentVersion }} (PURL: {{ .PreviousPURL }} ==> {{ .CurrentPURL }})
 {{- end }}
+```
+{{- else if and (gt (len .BuildModified) 0) (gt (len .BuildModified) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages modified.
 {{- end }}
 
 ### Removed
-{{- if ne (len .BuildRemoved) 0 }}
+{{- if and (gt (len .BuildRemoved) 0) (lt (len .BuildRemoved) .ReceiptsShowLimit) }}
 ```
 {{- range .BuildRemoved }}
 {{ .Name }} {{ .Version }} (PURL: {{ .PURL }})
 {{- end }}
+```
+{{- else if and (gt (len .BuildRemoved) 0) (gt (len .BuildRemoved) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages removed.
@@ -57,33 +69,45 @@ No packages removed.
 
 ## Run Image Package Changes
 ### Added
-{{- if ne (len .RunAdded) 0 }}
+{{- if and (gt (len .RunAdded) 0) (lt (len .RunAdded) .ReceiptsShowLimit) }}
 ```
 {{- range .RunAdded }}
 {{ .Name }} {{ .Version }} (PURL: {{ .PURL }})
 {{- end }}
+```
+{{- else if and (gt (len .RunAdded) 0) (gt (len .RunAdded) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages added.
 {{- end }}
 
 ### Modified
-{{- if ne (len .RunModified) 0 }}
+{{- if and (gt (len .RunModified) 0) (lt (len .RunModified) .ReceiptsShowLimit) }}
 ```
 {{- range .RunModified }}
 {{ .Name }} {{ .PreviousVersion }} ==> {{ .CurrentVersion }} (PURL: {{ .PreviousPURL }} ==> {{ .CurrentPURL }})
 {{- end }}
+```
+{{- else if and (gt (len .RunModified) 0) (gt (len .RunModified) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages modified.
 {{- end }}
 
 ### Removed
-{{- if ne (len .RunRemoved) 0 }}
+{{- if and (gt (len .RunRemoved) 0) (lt (len .RunRemoved) .ReceiptsShowLimit) }}
 ```
 {{- range .RunRemoved }}
 {{ .Name }} {{ .Version }} (PURL: {{ .PURL }})
 {{- end }}
+```
+{{- else if and (gt (len .RunRemoved) 0) (gt (len .RunRemoved) .ReceiptsShowLimit) }}
+```
+❌ TOO large to include
 ```
 {{- else }}
 No packages removed.

--- a/actions/stack/release-notes/entrypoint/template.md
+++ b/actions/stack/release-notes/entrypoint/template.md
@@ -8,6 +8,8 @@ Run: `{{- .RunImage -}}`
 
 {{- if .SupportsUsns }}
 
+{{- if .SupportsUsns }}
+
 ## Patched USNs
 {{- if ne (len .PatchedArray) 0 }}
 {{ range .PatchedArray }}
@@ -17,8 +19,6 @@ Run: `{{- .RunImage -}}`
 No USNs patched in this release.
 {{- end }}
 {{- end }}
-
-{{- if .BuildImage}}
 
 ## Build Image Package Changes
 ### Added

--- a/actions/stack/release-notes/entrypoint/template.md
+++ b/actions/stack/release-notes/entrypoint/template.md
@@ -8,8 +8,6 @@ Run: `{{- .RunImage -}}`
 
 {{- if .SupportsUsns }}
 
-{{- if .SupportsUsns }}
-
 ## Patched USNs
 {{- if ne (len .PatchedArray) 0 }}
 {{ range .PatchedArray }}
@@ -19,6 +17,8 @@ Run: `{{- .RunImage -}}`
 No USNs patched in this release.
 {{- end }}
 {{- end }}
+
+{{- if .BuildImage}}
 
 ## Build Image Package Changes
 ### Added


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds an option called `receipts-show-limit` where in case the limit, which corresponds to the number of items of the array for each removed, build or added, has been exceeded, then it hides the receipts by replacing them with the message `❌ TOO large to include` 

E.g if we set the limit to 0 it will show below readme file
```markdown
    ## Images
    Build: `build_image_url`
    Run: `run_image_url`
    
    ## Patched USNs
    No USNs patched in this release.
    
    ## Build Image Package Changes
    ### Added
    ```
    ❌ TOO large to include
    ```
    
    ### Modified
    
    ```
    ❌ TOO large to include
    ```
    
    ### Removed
    ```
    ❌ TOO large to include
    ```
    
    ## Run Image Package Changes
    ### Added
    ```
    ❌ TOO large to include
    ```
    
    ### Modified
    ```
    ❌ TOO large to include
    ```
    
    ### Removed
    ```
    ❌ TOO large to include
    ```

```
Instead of below one. 
```markdown
    ## Images
    Build: `build_image_url`
    Run: `run_image_url`
    
    ## Build Image Package Changes
    ### Added
    ```
    liba-dev 2.22.2-222.222 (PURL: pkg:purl/purl/linux)
    ```
    
    ### Modified
    ```
    liba-dev 1.11.1-111.111 ==> 2.22.2-222.222 (PURL: pkg:previous/purl/linux ==> pkg:previous/purl/linux)
    ```
    
    ### Removed
    ```
    liba-dev 2.22.2-222.222 (PURL: pkg:purl/purl/linux)
    ```
    
    ## Run Image Package Changes
    ### Added
    ```
    liba-dev 2.22.2-222.222 (PURL: pkg:purl/purl/linux)
    ```
    
    ### Modified
    ```
    liba-dev 1.11.1-111.111 ==> 2.22.2-222.222 (PURL: pkg:previous/purl/linux ==> pkg:previous/purl/linux)
    ```
    
    ### Removed
    ```
    liba-dev 2.22.2-222.222 (PURL: pkg:purl/purl/linux)
    ```
```

In case the value has not been set, it fallbacks to the current behaviour by showing all the receipts.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This is useful to avoid the Github error while posting the release notes. Github has a specific number of characters that allows the length of release notes to be. By setting a limit on whether the receipts if overcome it will show them or not, we avoid getting that error, especially when we newly add a stack.

## Merge after
* https://github.com/paketo-buildpacks/github-config/pull/939

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
