### PR TITLE
Publish-drafts action: fix edge case

### DIFF
--- a/actions/release/publish-drafts/entrypoint
+++ b/actions/release/publish-drafts/entrypoint
@@ -34,8 +34,12 @@ function main() {
 
   gh auth status
 
-  # get all draft releases, and sort them in ascending order so the highest semver release, is published as "latest"
-  versions=$(gh api /repos/${repo}/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | sort')
+  # Publish the highest semver release as "latest":
+  # get all draft releases
+  # trim off the 'v' in the version
+  # separates each part of the version
+  # sorts in ascending order
+  versions=$(gh api /repos/${repo}/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | map(ltrimstr("v")) | sort_by( split(".") | map(tonumber) )')
   if [[ $(jq length <<<"$versions") -eq 0 ]]; then
     echo "Nothing to release!"
   else


### PR DESCRIPTION
Fixes an edge case in the publish-drafts action:
Old behaviour, resulting in occasional wrong sort order:
```
 gh api /repos/<REPO>/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | sort'
[
  "v0.10.2",
  "v0.5.14",
  "v0.7.11",
  "v0.8.13",
  "v0.9.9"
]
```
New behaviour:
```
 ‣ gh api /repos/<REPO>/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | map(ltrimstr("v")) | sort_by( split(".") | map(tonumber) )'
[
  "0.5.14",
  "0.7.11",
  "0.8.13",
  "0.9.9",
  "0.10.2"
]
```