### PR TITLE
Adding back "v" in order for the release to be found.

### DIFF
--- a/actions/release/publish-drafts/entrypoint
+++ b/actions/release/publish-drafts/entrypoint
@@ -59,8 +59,8 @@ function publish() {
   release="${1}"
   repo="${2}"
 
-  echo "Publishing ${release} for ${repo}"
-  gh release edit ${release} -R ${repo} --draft=false
+  echo "Publishing v${release} for ${repo}"
+  gh release edit v${release} -R ${repo} --draft=false
 }
 
 main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds the "v" character in front of the release version, as otherwise, it is unable to find and publish it. Specifically on the below actions, the publish draft release action fails due to the "v" character being removed in order to do the ordering. Adding it back manages to find and publish the draft release.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Related issues to close after
* https://github.com/paketo-community/ubi-nodejs-extension/issues/160#issuecomment-2162477574
* https://github.com/paketo-buildpacks/node-run-script/issues/310
* https://github.com/paketo-buildpacks/node-start/issues/522
* https://github.com/paketo-buildpacks/yarn-start/issues/502
* https://github.com/paketo-buildpacks/node-engine/issues/937
* https://github.com/paketo-buildpacks/npm-install/issues/707
* https://github.com/paketo-buildpacks/yarn/issues/570
* https://github.com/paketo-buildpacks/npm-start/issues/504


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
