### PR TITLE
publish drafts bug fix: re-add v version prefix

### DIFF
--- a/actions/release/publish-drafts/entrypoint
+++ b/actions/release/publish-drafts/entrypoint
@@ -36,19 +36,25 @@ function main() {
 
   # Publish the highest semver release as "latest":
   # get all draft releases
-  # trim off the 'v' in the version
+  # trim off the 'v' prefix in the version
   # separates each part of the version
-  # sorts in ascending order
-  versions=$(gh api /repos/${repo}/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | map(ltrimstr("v")) | sort_by( split(".") | map(tonumber) )')
+  # sorts versions in ascending order
+  # readd the 'v' prefix to each version (needed for gh CLI to find the release correctly)
+
+  versions=$(gh api /repos/${repo}/releases | jq -r '[.[] | select(.draft == true) | .tag_name] | map(ltrimstr("v")) | sort_by( split(".") | map(tonumber) ) | map("v" + .)')
+
   if [[ $(jq length <<<"$versions") -eq 0 ]]; then
     echo "Nothing to release!"
   else
     if [[ "${all}" == "true" ]]; then
+      # publish ALL draft releases, in order of lowest semantic version to highest
       for release in $(echo ${versions} | jq -r .[]); do
         publish "${release}" "${repo}"
       done
     else
-      release=$(echo ${versions} | jq -r .[0])
+      # publish the LAST element in the version list
+      # this corresponds to the HIGHEST semver version
+      release=$(echo ${versions} | jq -r .[-1])
       publish "${release}" "${repo}"
     fi
   fi


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Fixes bug we saw in publishing draft releases ([example](https://github.com/paketo-buildpacks/bundler/actions/runs/9477130331/job/26111171035)), in which no releases went out because the `v` version prefix had been trimmed off the tag versions for sorting, and then we never re-added them.

I have tested this locally end to end and seen this work successfully now. Sorry for the noise!

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
