### PR TITLE
fix: Setting absolute path for validating extension.toml file existence.

### DIFF
--- a/implementation/scripts/build.sh
+++ b/implementation/scripts/build.sh
@@ -58,7 +58,7 @@ function run::build() {
 
       names=("detect")
 
-      if [ -f "extension.toml" ]; then
+      if [ -f "${BUILDPACKDIR}/extension.toml" ]; then
         names+=("generate")
       else
         names+=("build")


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
During the build process, we rely on whether to link build or generate according to extension.toml file existence. Currently, the validation does not correctly find the path of the extension.toml. This PR fixes the build.sh script, to find the path of the extension.toml correctly by changing it from a relative to an absolute path.
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
