### PR TITLE
Release notes: option for specifying on summarize whether is a buildpack or an extension

### DIFF
--- a/actions/release/notes/action.yml
+++ b/actions/release/notes/action.yml
@@ -13,6 +13,9 @@ inputs:
   buildpackage_path:
     description: 'Relative path to the .cnb buildpackage'
     default: 'build/buildpackage.cnb'
+  buildpack_type:
+    description: 'Specifies whether it is a buildpack or an extension'
+    default: 'buildpack'
 
 outputs:
   release_body:
@@ -28,3 +31,5 @@ runs:
   - ${{ inputs.token }}
   - "--buildpackage-path"
   - ${{ inputs.buildpackage_path }}
+  - "--buildpack-type"
+  - ${{ inputs.buildpack_type }}

--- a/actions/release/notes/entrypoint
+++ b/actions/release/notes/entrypoint
@@ -3,7 +3,7 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 function main() {
-  local token repo buildpackage_path
+  local token repo buildpackage_path buildpack_type
   while [ "${#}" != 0 ]; do
     case "${1}" in
       --token)
@@ -18,6 +18,11 @@ function main() {
 
       --buildpackage-path)
         buildpackage_path="${2}"
+        shift 2
+        ;;
+
+      --buildpack-type)
+        buildpack_type="${2}"
         shift 2
         ;;
 
@@ -65,7 +70,7 @@ function main() {
   local content
   content="$(
     jam summarize \
-      --buildpack "${GITHUB_WORKSPACE}/${buildpackage_path}" \
+      --"${buildpack_type}" "${GITHUB_WORKSPACE}/${buildpackage_path}" \
       --format markdown
   )"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request, please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds an extra argument called `--buildpack-type` on the `paketo-buildpacks/github-config/actions/release/notes` action. That way, we can specify for which type of buildpack (buildpack or extension) the release notes should be generated.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
