### PR TITLE
Output semver bump from buildpack update action.

### DIFF
--- a/actions/buildpack/update/action.yml
+++ b/actions/buildpack/update/action.yml
@@ -17,6 +17,11 @@ inputs:
     description: 'Allow only buildpack patch updates'
     default: 'false'
 
+outputs:
+  semver_bump:
+    description: 'The highest semver bump across all updated dependencies in the buildpack.toml'
+    value: ${{ steps.update.outputs.semver_bump }}
+
 runs:
   using: 'composite'
   steps:
@@ -32,6 +37,7 @@ runs:
       echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
   - name: Install Jam
+    id: install
     shell: bash
     run: |
       #!/usr/bin/env bash
@@ -49,13 +55,20 @@ runs:
       chmod +x "${HOME}/bin/jam"
 
   - name: Update Buildpack
+    id: update
     shell: bash
     run: |
       #!/usr/bin/env bash
       set -euo pipefail
       shopt -s inherit_errexit
-      jam update-buildpack \
+
+      output="$(jam update-buildpack \
         --buildpack-file "${PWD}/${{ inputs.buildpack_toml_path }}" \
         --package-file "${PWD}/${{ inputs.package_toml_path }}" \
         --no-cnb-registry="${{ inputs.no_cnb_registry }}" \
-        --patch-only="${{ inputs.patch_only }}"
+        --patch-only="${{ inputs.patch_only }}" )"
+
+      # output looks like: 'Highest semver bump: <patch|minor|major|<none>>'
+      semver_bump=$(echo "${output}" | cut -d' ' -f4)
+      echo "semver_bump=${semver_bump}"
+      echo "semver_bump=${semver_bump}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR adds support for outputting the semver version when bumping the buildpack. It utilizes the newly added semver output in `jam` ([jam PR](https://github.com/paketo-buildpacks/jam/pull/343/files))

~~Technically this will break if used against an older version of `jam`. I could guard against that, but I'd rather use the broken builds as a forcing function to ensure that we keep `jam` up to date everywhere. This is similar to what we did when adding the `--patch-only` to this action - we expect it to run against a newer version of `jam`.~~

Turns out this _won't_ break against an older version of `jam` - it will just emit an empty string for the semver bump. We can guard against this in the workflow (i.e. don't attempt to add a blank `semver:` label). We would probably want to do this anyway for safety.