### PR TITLE
Fixing syntax error on stack test.sh scripts

### DIFF
--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -241,7 +241,7 @@ function util::tools::skopeo::check () {
   local version
   version="v$(skopeo -v | awk '{ print $3}')"
 
-  util::print::title "Using installed skopeo version ${version}"
+  util::print::info "Using installed skopeo version ${version}"
 }
 
 function util::tools::tests::checkfocus() {
@@ -303,9 +303,10 @@ function util::tools::crane::install() {
       "${curl_args[@]}" | tar -C "${dir}" -xz crane
 
     chmod +x "${dir}/crane"
+  else
+    util::print::info "Using crane $("${dir}"/crane version)"
   fi
 }
-
 
 # Returns a random unused port
 function get::random::port() {

--- a/stack/scripts/test.sh
+++ b/stack/scripts/test.sh
@@ -79,6 +79,7 @@ function main() {
   if [[ "${setupLocalRegistry}" == "true" ]]; then
     kill $registryPid
   fi
+}
 
 function join_by {
   local d=${1-} f=${2-}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
* I missed closing a curly bracket on `test.sh` script and therefore, below PRs on syncing the changes for the registry are failing.
  * https://github.com/paketo-buildpacks/jammy-static-stack/actions/runs/9771547170/job/26974452884?pr=131
  * https://github.com/paketo-buildpacks/jammy-tiny-stack/actions/runs/9771583535/job/26974548101?pr=159
  * https://github.com/paketo-buildpacks/jammy-base-stack/pull/153
* Added logging the `crane` version, in case it is already installed, similar to what other tools do.
* Changed the `util::print::title` to `util::print::info` for `skopeo` to be consistent with what the other tools log.
 
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
