### PR TITLE
Update go version as well as toolchain version.

### DIFF
--- a/actions/update-go-mod-version/action.yml
+++ b/actions/update-go-mod-version/action.yml
@@ -3,13 +3,13 @@ description: |
   Updates the versions of go and the go toolchain in a go.mod file
 
 inputs:
-  toolchain-version:
-    description: 'Version of the toolchain to write'
+  go-version:
+    description: 'Version of go to write for both the go version and the toolchain version'
     required: true
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - "--toolchain-version"
-  - "${{ inputs.toolchain-version }}"
+  - "--go-version"
+  - "${{ inputs.go-version }}"

--- a/actions/update-go-mod-version/entrypoint
+++ b/actions/update-go-mod-version/entrypoint
@@ -4,14 +4,13 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 function main() {
-  local min_go_version toolchain_version
-  min_go_version="1.21" # 1.21 is the minimum to use the toolchain directive in go.mod
-  toolchain_version=""
+  local go_version
+  go_version=""
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
-      --toolchain-version)
-        toolchain_version="${2}"
+      --go-version)
+        go_version="${2}"
         shift 2
         ;;
 
@@ -26,38 +25,21 @@ function main() {
     esac
   done
   
-  if [[ -z "${toolchain_version}" ]]; then
-    echo "Must provide toolchain version"
+  if [[ -z "${go_version}" ]]; then
+    echo "Must provide go version"
     exit 1
   fi
 
-  found_go_version="$(grep -E 'go ([0-9]+\.[0-9]+)' < go.mod | sed 's/go //g')"
+  echo "Setting go version to: '${go_version}'"
+  sed -i "s/go .*/go ${go_version}/g" go.mod
 
-  if lt "${found_go_version}" "${min_go_version}"; then
-    echo "Updating go version to the minimum required version '${min_go_version}' (was '${found_go_version}')"
-    sed -i "s/go ${found_go_version}/go ${min_go_version}/g" go.mod
-    found_go_version="${min_go_version}"
-  else
-    echo "not updating go version as current version (${found_go_version}) is >= minimum required version (${min_go_version})"
-  fi
-
-  echo "setting toolchain to: '${toolchain_version}'"
+  echo "setting toolchain to: '${go_version}'"
   if grep -qE 'toolchain go(.*)' < go.mod; then 
-    sed -i "s/toolchain go.*/toolchain go${toolchain_version}/g" go.mod    
+    sed -i "s/toolchain go.*/toolchain go${go_version}/g" go.mod
   else
     # Write the toolchain directive two lines below the go version
-    sed -i "/go ${found_go_version}/r"<(printf "\ntoolchain go%s\n" "${toolchain_version}") go.mod
+    sed -i "/go ${go_version}/r"<(printf "\ntoolchain go%s\n" "${go_version}") go.mod
   fi
-}
-
-# returns $1 <= $2
-function lte() {
-  [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" == "$1" ]]
-}
-
-# returns $1 < $2
-function lt() {
-  ! lte "$2" "$1"
 }
 
 main "${@:-}"

--- a/builder/.github/workflows/update-go-mod-version.yml
+++ b/builder/.github/workflows/update-go-mod-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: current-go-version
         uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
-          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+          go-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy
         run: |
           #!/usr/bin/env bash
@@ -54,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          message: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -70,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:

--- a/implementation/.github/workflows/update-go-mod-version.yml
+++ b/implementation/.github/workflows/update-go-mod-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: current-go-version
         uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
-          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+          go-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy
         run: |
           #!/usr/bin/env bash
@@ -54,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          message: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -70,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:

--- a/language-family/.github/workflows/update-go-mod-version.yml
+++ b/language-family/.github/workflows/update-go-mod-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: current-go-version
         uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
-          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+          go-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy
         run: |
           #!/usr/bin/env bash
@@ -54,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          message: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -70,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:

--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: current-go-version
         uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
-          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+          go-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy
         run: |
           #!/usr/bin/env bash
@@ -54,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          message: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -70,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:

--- a/stack/.github/workflows/update-go-mod-version.yml
+++ b/stack/.github/workflows/update-go-mod-version.yml
@@ -27,7 +27,7 @@ jobs:
         id: current-go-version
         uses: paketo-buildpacks/github-config/actions/update-go-mod-version@main
         with:
-          toolchain-version: ${{ steps.setup-go.outputs.go-version }}
+          go-version: ${{ steps.setup-go.outputs.go-version }}
       - name: Go mod tidy
         run: |
           #!/usr/bin/env bash
@@ -54,7 +54,7 @@ jobs:
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
         with:
-          message: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          message: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           pathspec: "."
           keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
           key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
@@ -70,7 +70,7 @@ jobs:
         uses: paketo-buildpacks/github-config/actions/pull-request/open@main
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-          title: "Updates go mod toolchain version to ${{ steps.setup-go.outputs.go-version }}"
+          title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
           branch: automation/go-mod-update/update-main
 
   failure:


### PR DESCRIPTION
This PR changes the behavior of the action that updates the go toolchain version to also update the `go` version in addition to updating the `toolchain` version. This is necessary because some of our dependencies have higher versions of go than we do and in order to keep them up to date we must also bump to the minimum version of go that they have. Rather than trying to identify the lowest-common-denominator across all dependencies it is easier to always use the latest version.

If we wanted to ensure that we did not need the latest version of go, we could choose to not bump these dependencies. But I think we should keep our dependencies up to date and accept the golang bump. Especially because most of our products are binaries and not libraries, and hence we can control the version of golang they are built with.

See [this conversation](https://github.com/sylabs/sif/issues/370) for more details.

I opted to keep the `toolchain` directive even though it's probably no longer necessary because I felt like being explicit is probably better than relying on the default behavior, given how confusing this situation is for all of us.