### PR TITLE
Update update-go-mod-version.yml

### DIFF
--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -63,7 +63,7 @@ jobs:
         if: ${{ steps.commit.outputs.commit_sha != '' }}
         uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
         with:
-          branch: automation/go-mod-update/update-main
+          branch: automation/go-mod-update/update
 
       - name: Open Pull Request
         if: ${{ steps.commit.outputs.commit_sha != '' }}
@@ -71,7 +71,8 @@ jobs:
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
-          branch: automation/go-mod-update/update-main
+          branch: automation/go-mod-update/update
+          base: ${{ github.event.repository.default_branch }}
 
   failure:
     name: Alert on Failure


### PR DESCRIPTION
Makes PR against `default_branch` instead of `main` which is the default branch for this action. This is causing the `packit` `v2` branch (which is the default) to not be updated.