### PR TITLE
Fixing error on update stack tools by adding crane missing argument

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -106,6 +106,7 @@ jobs:
            --arg pack "${PACK_VERSION}" \
            --arg jam "${JAM_VERSION}" \
            --arg syft "${SYFT_VERSION}" \
+           --arg crane "${CRANE_VERSION}" \
            '{ pack: $pack, jam: $jam, syft: $syft, crane: $crane }' > ./stack/scripts/.util/tools.json
 
     - name: Commit


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes the failure on updating stack tools due to crane `ENV` variable is missing.
* https://github.com/paketo-buildpacks/github-config/actions/runs/10762619641/job/29843175151

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
