### PR TITLE
Remove unnecessary tmp file

### DIFF
--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -142,12 +142,10 @@ function util::tools::pack::install() {
       pack_config_enable_experimental="false"
     fi
 
-    tmp_location="/tmp/pack.tgz"
     curl_args=(
       "--fail"
       "--silent"
       "--location"
-      "--output" "${tmp_location}"
     )
 
     if [[ "${token}" != "" ]]; then
@@ -160,16 +158,14 @@ function util::tools::pack::install() {
     arch=$(util::tools::arch --blank-amd64)
 
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}${arch:+-$arch}.tgz" \
-      "${curl_args[@]}"
-
-    tar xzf "${tmp_location}" -C "${dir}"
+      "${curl_args[@]}" | \
+        tar xzf - -C "${dir}"
     chmod +x "${dir}/pack"
 
     if [[ "${pack_config_enable_experimental}" == "true" ]]; then
       "${dir}"/pack config experimental true
     fi
 
-    rm "${tmp_location}"
   else
     util::print::info "Using pack $("${dir}"/pack version)"
   fi


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Removed unnecessary intermediary file for `pack` installation `/tmp/pack.tgz`
The file is completely unnecessary since pipe can be used.
What's more important: the temp file has fixed name thus creating datarace.
If anything the names should be unique for each invocation for instance by using `mktemp`.

## Use Cases
This enables parallel build for multiple buildpacks at the same time on the same machine.
Obviously it would be best if each build did not install `pack` for itself all over again...

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
