### PR TITLE
Buildpacks - Implementation of multi-arch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .DS_Store
 *.tgz
 .idea
-.bin
+/.bin
+/build
+/bin
+/linux
+/darwin
+/windows

--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -61,6 +61,12 @@ jobs:
     name: Release
     runs-on: ubuntu-22.04
     needs: integration
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -110,6 +116,16 @@ jobs:
           echo "buildpack_type=buildpack" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Get buildpack path
+      id: get_buildpack_path
+      run: |
+
+        if [ -f "build/buildpackage.cnb" ]; then
+          echo "path=build/buildpackage.cnb" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=build/buildpackage-linux-amd64.cnb" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Create Release Notes
       id: create-release-notes
       uses: paketo-buildpacks/github-config/actions/release/notes@main
@@ -117,6 +133,69 @@ jobs:
         repo: ${{ github.repository }}
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         buildpack_type: ${{ steps.get_buildpack_type.outputs.buildpack_type }}
+        buildpackage_path: ${{ steps.get_buildpack_path.outputs.path }}
+
+    - name: Get Image Digest
+      id: image_digest
+      run: |
+        image_name="localhost:5000/npm-install:latest"
+
+        ./scripts/publish.sh \
+          --buildpack-archive ./build/buildpack.tgz \
+          --image-ref $image_name
+
+        echo "digest=$(sudo skopeo inspect "docker://${image_name}" --tls-verify=false | jq -r .Digest)" >> "$GITHUB_OUTPUT"
+
+    - name: Set Correct Image Digest on the Release notes
+      run: |
+          printf '${{ steps.create-release-notes.outputs.release_body }}' \
+            | sed -E \
+              "s/\*\*Digest:\*\* \`sha256:[a-f0-9]{64}\`/\*\*Digest:\*\* \`${{ steps.image_digest.outputs.digest }}\`/" \
+              > ./release_notes
+
+          printf '${{ steps.image_digest.outputs.digest }}' > ./index-digest.sha256
+
+    - name: Create release assets
+      id: create_release_assets
+      run: |
+        release_assets=$(jq -n --arg repo_name "${{ github.event.repository.name }}" --arg tag "${{ steps.tag.outputs.tag }}" '
+        [
+          {
+            "path": "build/buildpack.tgz",
+            "name": ($repo_name + "-" + $tag + ".tgz"),
+            "content_type": "application/gzip"
+          },
+          {
+            "path": "./index-digest.sha256",
+            "name": ($repo_name + "-" + $tag + "-" + "index-digest.sha256"),
+            "content_type": "text/plain"
+          }
+        ]')
+
+        for filepath in build/*.cnb; do
+          filename=$(basename "$filepath")
+          asset_name=""
+          if [[ "$filename" == "buildpackage-linux-amd64.cnb" ]]; then
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb"
+          elif [[ "$filename" == "buildpackage.cnb" ]]; then
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb"
+          else
+            formatted_filename="${filename#buildpackage-}"
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}-${formatted_filename}"
+          fi
+
+          release_assets=$(echo "$release_assets" | jq --arg asset_name "${asset_name}" --arg filepath "$filepath" '
+          . + [
+            {
+              "path": $filepath,
+              "name": $asset_name,
+              "content_type": "application/gzip"
+            }
+          ]')
+        done
+
+        release_assets=$(jq -c <<< "$release_assets" )
+        printf "release_assets=%s\n" "${release_assets}" >> "$GITHUB_OUTPUT"
 
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
@@ -126,21 +205,9 @@ jobs:
         tag_name: v${{ steps.tag.outputs.tag }}
         target_commitish: ${{ github.sha }}
         name: v${{ steps.tag.outputs.tag }}
-        body: ${{ steps.create-release-notes.outputs.release_body }}
+        body_filepath: "./release_notes"
         draft: true
-        assets: |
-          [
-            {
-              "path": "build/buildpack.tgz",
-              "name": "${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.tgz",
-              "content_type": "application/gzip"
-            },
-            {
-              "path": "build/buildpackage.cnb",
-              "name": "${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb",
-              "content_type": "application/gzip"
-            }
-          ]
+        assets: ${{ steps.create_release_assets.outputs.release_assets }}
 
   failure:
     name: Alert on Failure

--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -4,13 +4,22 @@ on:
   release:
     types:
     - published
+
 env:
   REGISTRIES_FILENAME: "registries.json"
 
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    env:
+      GCR_REGISTRY: "gcr.io"
+      GCR_PASSWORD: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+      GCR_USERNAME: "_json_key"
+      DOCKERHUB_REGISTRY: docker.io
+      DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+
     steps:
 
     - name: Checkout
@@ -25,30 +34,43 @@ jobs:
         echo "tag_full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
         echo "tag_minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
         echo "tag_major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-        echo "download_url=$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_tgz_file_url=$(jq -r '.release.assets[] | select(.name | endswith(".tgz")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_cnb_file_url=$(jq -r --arg tag_full "$FULL_VERSION" '.release.assets[] | select(.name | endswith($tag_full + ".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_sha256_file_url=$(jq -r '.release.assets[] | select(.name | endswith("index-digest.sha256")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
-    - name: Download
-      id: download
+    - name: Download .cnb buildpack
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
       with:
-        url: ${{ steps.event.outputs.download_url }}
+        url: ${{ steps.event.outputs.download_cnb_file_url }}
         output: "/github/workspace/buildpackage.cnb"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download .tgz buildpack
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.download_tgz_file_url }}
+        output: "/github/workspace/buildpack.tgz"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download .sha digest
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.download_sha256_file_url }}
+        output: "/github/workspace/index-digest.sha256"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
     - name: Parse Configs
       id: parse_configs
       run: |
-        registries_filename="${{ env.REGISTRIES_FILENAME }}"
-
         push_to_dockerhub=true
         push_to_gcr=true
 
-        if [[ -f $registries_filename ]]; then
-          if jq 'has("dockerhub")' $registries_filename > /dev/null; then
-            push_to_dockerhub=$(jq '.dockerhub' $registries_filename)
+        if [[ -f $REGISTRIES_FILENAME ]]; then
+          if jq 'has("dockerhub")' $REGISTRIES_FILENAME > /dev/null; then
+            push_to_dockerhub=$(jq '.dockerhub' $REGISTRIES_FILENAME)
           fi
-          if jq 'has("GCR")' $registries_filename > /dev/null; then
-            push_to_gcr=$(jq '.GCR' $registries_filename)
+          if jq 'has("GCR")' $REGISTRIES_FILENAME > /dev/null; then
+            push_to_gcr=$(jq '.GCR' $REGISTRIES_FILENAME)
           fi
         fi
 
@@ -64,41 +86,64 @@ jobs:
           exit 1
         fi
 
-    - name: Push to GCR
-      if: ${{  steps.parse_configs.outputs.push_to_gcr == 'true' }}
-      env:
-        GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
-      run: |
-        echo "${GCR_PUSH_BOT_JSON_KEY}" | sudo skopeo login --username _json_key --password-stdin gcr.io
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_full }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_minor }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_major }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:latest"
+    - name: Docker login docker.io
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
+        registry: ${{ env.DOCKERHUB_REGISTRY }}
+
+    - name: Docker login gcr.io
+      uses: docker/login-action@v3
+      if: ${{ steps.parse_configs.outputs.push_to_gcr == 'true' }}
+      with:
+        username: ${{ env.GCR_USERNAME }}
+        password: ${{ env.GCR_PASSWORD }}
+        registry: ${{ env.GCR_REGISTRY }}
 
     - name: Push to DockerHub
       if: ${{  steps.parse_configs.outputs.push_to_dockerhub == 'true' }}
       id: push
       env:
-        DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
-        DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       run: |
-        REPOSITORY="${GITHUB_REPOSITORY_OWNER/-/}/${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" # translates 'paketo-buildpacks/bundle-install' to 'paketobuildpacks/bundle-install'
-        IMAGE="index.docker.io/${REPOSITORY}"
-        echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin index.docker.io
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_full }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_minor }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_major }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:latest"
+        IMAGE="${GITHUB_REPOSITORY_OWNER/-/}/${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" # translates 'paketo-buildpacks/bundle-install' to 'paketobuildpacks/bundle-install'
+        echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin ${DOCKERHUB_REGISTRY}
+
+        ./scripts/publish.sh \
+          --buildpack-archive ./buildpack.tgz \
+          --image-ref "${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}"
+
+        ## Validate that the digest pushed to registry matches with the one mentioned on the readme file
+        pushed_image_index_digest=$(sudo skopeo inspect "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" | jq -r .Digest)
+
+        if [ "$(cat ./index-digest.sha256)" != "$pushed_image_index_digest" ]; then
+          echo "Image index digest pushed to registry does not match with the one mentioned on the readme file"
+          exit 1;
+        fi
+
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_minor }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_major }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:latest" --multi-arch all
         echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-        echo "digest=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)" >> "$GITHUB_OUTPUT"
+        echo "digest=$pushed_image_index_digest" >> "$GITHUB_OUTPUT"
+
+    - name: Push to GCR
+      if: ${{ steps.parse_configs.outputs.push_to_gcr == 'true' }}
+      run: |
+        echo "${GCR_PASSWORD}" | sudo skopeo login --username "${GCR_USERNAME}" --password-stdin "${GCR_REGISTRY}"
+
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_full }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_minor }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_major }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:latest" --multi-arch all
 
     - name: Register with CNB Registry
       uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:main
       with:
         id: ${{ github.repository }}
         version: ${{ steps.event.outputs.tag_full }}
-        address: ${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
+        address: index.docker.io/${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
   failure:

--- a/implementation/scripts/build.sh
+++ b/implementation/scripts/build.sh
@@ -3,16 +3,26 @@
 set -eu
 set -o pipefail
 
+readonly ROOT_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOT_DIR}/scripts/.util/print.sh"
+
 function main() {
+  local targets=()
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --help|-h)
         shift 1
         usage
         exit 0
+        ;;
+
+      --target)
+        targets+=("${2}")
+        shift 2
         ;;
 
       "")
@@ -27,8 +37,18 @@ function main() {
 
   mkdir -p "${BUILDPACKDIR}/bin"
 
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=("linux/amd64")
+    util::print::info "Setting default target platform architecture to: linux/amd64"
+  fi
+
   run::build
   cmd::build
+
+  ## For backwards compatibility with amd64 wokflows
+  if [[ ${#targets[@]} -eq 1 && "${targets[0]}" == "linux/amd64" ]]; then
+    cp -r "${BUILDPACKDIR}/linux/amd64/bin/" "${BUILDPACKDIR}/"
+  fi
 }
 
 function usage() {
@@ -38,39 +58,49 @@ build.sh [OPTIONS]
 Builds the buildpack executables.
 
 OPTIONS
-  --help  -h  prints the command usage
+  --target strings  Target platforms to build for.
+                    Targets should be in the format '[os][/arch][/variant]'.
+                      - To specify two different architectures: '--target "linux/amd64" --target "linux/arm64"'
+  --help  -h        prints the command usage
 USAGE
 }
 
 function run::build() {
   if [[ -f "${BUILDPACKDIR}/run/main.go" ]]; then
-    pushd "${BUILDPACKDIR}/bin" > /dev/null || return
-      printf "%s" "Building run... "
+    pushd "${BUILDPACKDIR}" > /dev/null || return
+      for target in "${targets[@]}"; do
+        platform=$(echo "${target}" | cut -d '/' -f1)
+        arch=$(echo "${target}" | cut -d'/' -f2)
 
-      GOOS=linux \
-      CGO_ENABLED=0 \
-        go build \
-          -ldflags="-s -w" \
-          -o "run" \
-            "${BUILDPACKDIR}/run"
+        util::print::title "Building run... for platform: ${platform} and arch: ${arch}"
 
-      echo "Success!"
+        GOOS=$platform \
+        GOARCH=$arch \
+        CGO_ENABLED=0 \
+          go build \
+            -ldflags="-s -w" \
+            -o "${platform}/${arch}/bin/run" \
+              "${BUILDPACKDIR}/run"
 
-      names=("detect")
+          echo "Success!"
 
-      if [ -f "${BUILDPACKDIR}/extension.toml" ]; then
-        names+=("generate")
-      else
-        names+=("build")
-      fi
+          names=("detect")
 
-      for name in "${names[@]}"; do
-        printf "%s" "Linking ${name}... "
+          if [ -f "${BUILDPACKDIR}/extension.toml" ]; then
+            names+=("generate")
+          else
+            names+=("build")
+          fi
 
-        ln -sf "run" "${name}"
+        for name in "${names[@]}"; do
+          printf "%s" "Linking ${name}... "
 
-        echo "Success!"
+          ln -fs "run" "${platform}/${arch}/bin/${name}"
+
+          echo "Success!"
+        done
       done
+
     popd > /dev/null || return
   fi
 }
@@ -80,21 +110,26 @@ function cmd::build() {
     local name
     for src in "${BUILDPACKDIR}"/cmd/*; do
       name="$(basename "${src}")"
+      for target in "${targets[@]}"; do
+        platform=$(echo "${target}" | cut -d '/' -f1)
+        arch=$(echo "${target}" | cut -d'/' -f2)
 
-      if [[ -f "${src}/main.go" ]]; then
-        printf "%s" "Building ${name}... "
+        if [[ -f "${src}/main.go" ]]; then
+          util::print::title "Building ${name}... for platform: ${platform} and arch: ${arch}"
 
-        GOOS="linux" \
-        CGO_ENABLED=0 \
-          go build \
-            -ldflags="-s -w" \
-            -o "${BUILDPACKDIR}/bin/${name}" \
-              "${src}/main.go"
+          GOOS=$platform \
+          GOARCH=$arch \
+          CGO_ENABLED=0 \
+            go build \
+              -ldflags="-s -w" \
+              -o "${BUILDPACKDIR}/${platform}/${arch}/bin/${name}" \
+                "${src}/main.go"
 
-        echo "Success!"
-      else
-        printf "%s" "Skipping ${name}... "
-      fi
+          echo "Success!"
+        else
+          printf "%s" "Skipping ${name}... "
+        fi
+      done
     done
   fi
 }

--- a/implementation/scripts/package.sh
+++ b/implementation/scripts/package.sh
@@ -144,26 +144,15 @@ function buildpackage::create() {
 
   util::print::title "Packaging ${buildpack_type}... ${output}"
 
-  if [ "$buildpack_type" == "extension" ]; then
-    cwd=$(pwd)
-    cd ${BUILD_DIR}
-    mkdir cnbdir
-    cd cnbdir
-    cp ../buildpack.tgz .
-    tar -xvf buildpack.tgz
-    rm buildpack.tgz
+  mkdir ${BUILD_DIR}/cnbdir
+  tar -xvf ${BUILD_DIR}/buildpack.tgz -C ${BUILD_DIR}/cnbdir
 
-    pack \
-      extension package "${output}" \
-        --format file
+  pack \
+    "${buildpack_type}" package "${output}" \
+      --path ${BUILD_DIR}/cnbdir \
+      --format file
 
-    cd $cwd
-  else
-    pack \
-      buildpack package "${output}" \
-        --path "${BUILD_DIR}/buildpack.tgz" \
-        --format file
-  fi
+  rm -rf ${BUILD_DIR}/cnbdir
 }
 
 main "${@:-}"

--- a/implementation/scripts/publish.sh
+++ b/implementation/scripts/publish.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+readonly ROOT_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
+readonly BIN_DIR="${ROOT_DIR}/.bin"
+
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${ROOT_DIR}/scripts/.util/tools.sh"
+
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOT_DIR}/scripts/.util/print.sh"
+
+function main {
+  local buildpack_archive image_ref token
+  token=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+    --buildpack-archive | -b)
+      buildpack_archive="${2}"
+      shift 2
+      ;;
+
+    --image-ref | -i)
+      image_ref+=("${2}")
+      shift 2
+      ;;
+
+    --token | -t)
+      token="${2}"
+      shift 2
+      ;;
+
+    --help | -h)
+      shift 1
+      usage
+      exit 0
+      ;;
+
+    "")
+      # skip if the argument is empty
+      shift 1
+      ;;
+
+    *)
+      util::print::error "unknown argument \"${1}\""
+      ;;
+    esac
+  done
+
+  if [[ -z "${image_ref:-}" ]]; then
+    usage
+    echo
+    util::print::error "--image-ref is required"
+  fi
+
+  if [[ -z "${buildpack_archive:-}" ]]; then
+    util::print::info "Using default buildpack archive path: ${ROOT_DIR}/build/buildpack.tgz"
+    buildpack_archive="${ROOT_DIR}/build/buildpack.tgz"
+  fi
+
+  repo::prepare
+
+  tools::install "${token}"
+
+  buildpack_type=buildpack
+  if [ -f "${ROOT_DIR}/extension.toml" ]; then
+    buildpack_type=extension
+  fi
+
+  buildpack::publish "${image_ref}" "${buildpack_type}"
+}
+
+function usage() {
+  cat <<-USAGE
+publish.sh --version <version> [OPTIONS]
+
+Publishes a buildpack or an extension in to a registry.
+
+OPTIONS
+  -h, --help                          Prints the command usage
+  -b, --buildpack-archive <filepath>  Path to the buildpack arhive (default: ${ROOT_DIR}/build/buildpack.tgz) (optional)
+  -i, --image-ref <ref>               List of image reference to publish to (required)
+  -t, --token <token>                 Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
+USAGE
+}
+
+function repo::prepare() {
+  util::print::title "Preparing repo..."
+
+  mkdir -p "${BIN_DIR}"
+
+  export PATH="${BIN_DIR}:${PATH}"
+}
+
+function tools::install() {
+  local token
+  token="${1}"
+
+  util::tools::pack::install \
+    --directory "${BIN_DIR}" \
+    --token "${token}"
+}
+
+function buildpack::publish() {
+
+  local image_ref buildpack_type
+  image_ref="${1}"
+  buildpack_type="${2}"
+
+  util::print::title "Publishing ${buildpack_type}..."
+
+  util::print::info "Extracting archive..."
+  tmp_dir=$(mktemp -d -p $ROOT_DIR)
+  tar -xvf $buildpack_archive -C $tmp_dir
+
+  util::print::info "Publishing ${buildpack_type} to ${image_ref}"
+  pack \
+    buildpack package $image_ref \
+    --path $tmp_dir \
+    --format image \
+    --publish
+
+  rm -rf $tmp_dir
+}
+
+main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
## Merge After
* https://github.com/ForestEckhardt/freezer/pull/12
* https://github.com/paketo-buildpacks/occam/pull/357
* [ ] Update occam with at least version 0.22.0 on all buildpacks.

## Summary
<!-- A short explanation of the proposed change -->
This PR adds support for multi-arch, more specifically:
* It supports backward compatibility, so it does not break any functionality, on the scripts, workflows, testing etc. of the current buildpacks.
* Is able to generate .cnb files for all the architectures declared on the buildpak.toml (see example https://github.com/paketo-buildpacks/npm-install/blob/b04dd76a037318298445fbfda532774e45b29436/buildpack.toml#L14-L26 )
* It has already been tested for a while in npm-install repo https://github.com/paketo-buildpacks/npm-install and it has also been tested on node-engine (personal repo).
* The naming convention for the artifacts on each release, is `repo-tag-platform-architecture` except for the `linux/amd64` targets that is `repo-tag` in order to keep backward compatibility. Example https://github.com/paketo-buildpacks/npm-install/releases/tag/v1.8.2
* It supports publishing multi-arch images to the registry, through the `publish.sh` script, which is newly introduced.
* It generates the hash codes for each .cnb file and it also generates the .tgz file.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
