### PR TITLE
Fix branch name for updating Go version for libraries

### DIFF
--- a/library/.github/workflows/update-go-mod-version.yml
+++ b/library/.github/workflows/update-go-mod-version.yml
@@ -63,7 +63,7 @@ jobs:
         if: ${{ steps.commit.outputs.commit_sha != '' }}
         uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
         with:
-          branch: automation/go-mod-update/update
+          branch: automation/go-mod-update/update-main
 
       - name: Open Pull Request
         if: ${{ steps.commit.outputs.commit_sha != '' }}
@@ -71,7 +71,7 @@ jobs:
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           title: "Updates go mod version to ${{ steps.setup-go.outputs.go-version }}"
-          branch: automation/go-mod-update/update
+          branch: automation/go-mod-update/update-main
           base: ${{ github.event.repository.default_branch }}
 
   failure:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Updating the Go version fails for repositories using the action in the library path. Examples:

- https://github.com/paketo-buildpacks/packit/actions/workflows/update-go-mod-version.yml
- https://github.com/paketo-buildpacks/packit/actions/workflows/update-go-mod-version.yml

This PR aligns the branch which is checked out initially (L 20) with the one that is pushed (L 66, 74). 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
