### PR TITLE
stack/get-usns general fixes/upgrades

### DIFF
--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'JSON array of stack package names'
     required: false
     default: '[]'
+  packages_filepath:
+    description: 'Similar to packages, but instead of pointing into a variables, it points to a file'
+    required: false
   distribution:
     description: 'Ubuntu distribution of stack (bionic|focal|jammy|noble)'
     required: true
@@ -35,5 +38,7 @@ runs:
   - "${{ inputs.last_usns }}"
   - "--packages"
   - "${{ inputs.packages }}"
+  - "--packages-filepath"
+  - "${{ inputs.packages_filepath }}"
   - "--distro"
   - "${{ inputs.distribution }}"

--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -25,6 +25,7 @@ inputs:
     description: 'Ubuntu distribution of stack (bionic|jammy)'
     required: false
     default: "bionic"
+    description: 'Ubuntu distribution of stack (bionic|focal|jammy|noble)'
 
 runs:
   using: 'docker'

--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -22,10 +22,8 @@ inputs:
     required: false
     default: '[]'
   distribution:
-    description: 'Ubuntu distribution of stack (bionic|jammy)'
-    required: false
-    default: "bionic"
     description: 'Ubuntu distribution of stack (bionic|focal|jammy|noble)'
+    required: true
 
 runs:
   using: 'docker'

--- a/actions/stack/get-usns/entrypoint/go.mod
+++ b/actions/stack/get-usns/entrypoint/go.mod
@@ -1,6 +1,6 @@
 module github.com/paketo-buildpacks/github-config/actions/stack/get-usns/entrypoint
 
-go 1.18
+go 1.24.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -44,12 +44,13 @@ type CVE struct {
 
 func main() {
 	var config struct {
-		Distro         string
-		LastUSNsJSON   string
-		Output         string
-		PackagesJSON   string
-		RSSURL         string
-		RetryTimeLimit string
+		Distro               string
+		LastUSNsJSON         string
+		Output               string
+		PackagesJSON         string
+		PackagesJSONFilepath string
+		RSSURL               string
+		RetryTimeLimit       string
 	}
 
 	flag.StringVar(&config.LastUSNsJSON,
@@ -64,6 +65,10 @@ func main() {
 		"packages",
 		"",
 		"JSON array of relevant packages")
+	flag.StringVar(&config.PackagesJSONFilepath,
+		"packages-filepath",
+		"",
+		"Filepath that points to the JSON array of relevant packages")
 	flag.StringVar(&config.Distro,
 		"distro",
 		"",
@@ -112,6 +117,19 @@ func main() {
 	err = json.Unmarshal([]byte(config.PackagesJSON), &packages)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if config.PackagesJSONFilepath != "" {
+
+		packagesFilepath, err := os.ReadFile(config.PackagesJSONFilepath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.Unmarshal(packagesFilepath, &packages)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	newUSNs, err := getNewUSNsFromFeed(config.RSSURL, lastUSNs, distroToVersionRegex[config.Distro], retryTimeLimit)

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -22,6 +22,7 @@ import (
 )
 
 var distroToVersionRegex map[string]string = map[string]string{
+	"noble":  `24\.04`,
 	"jammy":  `22\.04`,
 	"focal":  `20\.04`,
 	"bionic": `18\.04`,

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -297,7 +297,7 @@ func get(url string) (string, int, error) {
 
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", 0, err
 	}

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -66,8 +66,8 @@ func main() {
 		"JSON array of relevant packages")
 	flag.StringVar(&config.Distro,
 		"distro",
-		`bionic`,
-		"Name of Ubuntu distro: jammy, bionic")
+		"",
+		"Name of Ubuntu distro: bionic, focal, jammy, noble")
 	flag.StringVar(&config.Output,
 		"output",
 		"",
@@ -76,6 +76,18 @@ func main() {
 	flag.StringVar(&config.RetryTimeLimit, "retry-time-limit", "5m", "How long to retry failures for")
 
 	flag.Parse()
+
+	distroExists := distroToVersionRegex[config.Distro]
+	if distroExists == "" {
+		var validDistroValues = ""
+
+		for key := range distroToVersionRegex {
+			validDistroValues = validDistroValues + key + "\n"
+		}
+
+		errMessage := fmt.Sprintf("--distro flag has to be one of the following values: \n %s", validDistroValues)
+		log.Fatal(errMessage)
+	}
 
 	if config.LastUSNsJSON == "" {
 		config.LastUSNsJSON = `[]`

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -82,16 +82,9 @@ func main() {
 
 	flag.Parse()
 
-	distroExists := distroToVersionRegex[config.Distro]
-	if distroExists == "" {
-		var validDistroValues = ""
-
-		for key := range distroToVersionRegex {
-			validDistroValues = validDistroValues + key + "\n"
-		}
-
-		errMessage := fmt.Sprintf("--distro flag has to be one of the following values: \n %s", validDistroValues)
-		log.Fatal(errMessage)
+	_, ok := distroToVersionRegex[config.Distro]
+	if !ok {
+		log.Fatal(fmt.Sprintf("--distro flag has to be one of the following values: %v", slices.Sorted(maps.Keys(distroToVersionRegex))))
 	}
 
 	if config.LastUSNsJSON == "" {

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -8,11 +8,13 @@ import (
 	"html"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR does below things:
1. Adds noble on the regex expressions to properly scrap the usns from ubuntu page
2. Removes the default value from distribution, as it is better to error in case the user has not specified an ubuntu distribution compared to having a false fallback.
3. Upgrades `io/util` to `io`, as `io/util` is deprecated
4. Adds an extra flag called `packages_filepath` which is similar to packages and it enables passing the data through file. This is usefull in case there are a lot of packages, where in that case the workflow will fail due to terminal has a limit.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
