### PR TITLE
adding capability of outputing packages into a file

### DIFF
--- a/actions/stack/generate-package-list/action.yml
+++ b/actions/stack/generate-package-list/action.yml
@@ -7,10 +7,17 @@ inputs:
   run_receipt:
     description: 'Package receipt for run image'
     required: true
+  output_path:
+    description: 'Path where asset should be downloaded'
+    required: false
+
 outputs:
   packages:
-    description: 'JSON array of packages contained in build and run images'
+    description: 'JSON array of packages contained in build and run images. Empty if output_path is provided as input'
     value: ${{ steps.packages.outputs.packages }}
+  output_path:
+    description: 'Absolute path to the downloaded artifact. Empty if no output_path as input is provided'
+    value: ${{ steps.packages.outputs.output_path }}
 
 runs:
   using: 'composite'
@@ -25,4 +32,9 @@ runs:
       packages=$(jq  '.components[] |  .name' "${{ inputs.build_receipt }}" "${{ inputs.run_receipt }}" \
         | jq --null-input --compact-output '[inputs]')
 
-      printf "packages=%s\n" "${packages}" >> "$GITHUB_OUTPUT"
+      if [ -n "${{ inputs.output_path }}" ]; then
+        echo "${packages}" > "${{ inputs.output_path }}"
+        printf "output_path=%s\n" "${{ inputs.output_path }}" >> "$GITHUB_OUTPUT"
+      else
+        printf "packages=%s\n" "${packages}" >> "$GITHUB_OUTPUT"
+      fi


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds the option of storing the output of the action to a file instead of storing it to a variable. This is useful in case the output is more than what the github action terminal can handle, where in that case it will fail.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
