### PR TITLE
Configurable builder.toml filename

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -7,6 +7,10 @@ inputs:
   token:
     description: 'Github Access Token used to make the request'
     required: true
+  filename:
+    description: 'Name of the builder.toml file to update'
+    required: false
+    default: 'builder.toml'
 
 runs:
   using: 'composite'
@@ -54,4 +58,4 @@ runs:
       set -euo pipefail
       shopt -s inherit_errexit
       jam update-builder \
-        --builder-file "${PWD}/builder.toml"
+        --builder-file "${PWD}/${{ inputs.filename }}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
`builder.toml` is currently hardcoded in the update action and does not work for `builder-buildpackless.toml`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
https://github.com/paketo-buildpacks/rfcs/blob/main/text/0061-core-builder.md#implementation

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
