### PR TITLE
Introducing --output flag on get-usns action.

### DIFF
--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -6,7 +6,7 @@ description: |
 
 outputs:
   usns:
-    description: JSON array of patched USNs or file path to JSON array, if --output flag is specified
+    description: JSON array of patched USNs or path to JSON file, if usns_output_path flag is specified
 
 inputs:
   feed_url:

--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -6,7 +6,7 @@ description: |
 
 outputs:
   usns:
-    description: JSON array of patched USNs
+    description: JSON array of patched USNs or file path to JSON array, if --output flag is specified
 
 inputs:
   feed_url:
@@ -27,6 +27,9 @@ inputs:
   distribution:
     description: 'Ubuntu distribution of stack (bionic|focal|jammy|noble)'
     required: true
+  usns_output_path:
+    description: 'Path to output usns JSON file'
+    required: false
 
 runs:
   using: 'docker'
@@ -42,3 +45,5 @@ runs:
   - "${{ inputs.packages_filepath }}"
   - "--distro"
   - "${{ inputs.distribution }}"
+  - "--output"
+  - "${{ inputs.usns_output_path }}"

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -151,7 +151,6 @@ func main() {
 		output = []byte(`[]`)
 	}
 
-	fmt.Println("Output: ", string(output))
 	outputFileName, ok := os.LookupEnv("GITHUB_OUTPUT")
 	if !ok {
 		log.Fatal("GITHUB_OUTPUT is not set, see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter")

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -160,7 +160,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer file.Close()
-	fmt.Fprintf(file, "usns=%s\n", string(output))
 
 	if config.Output != "" {
 		path, err := filepath.Abs(config.Output)
@@ -171,6 +170,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	} else {
+		fmt.Fprintf(file, "usns=%s\n", string(output))
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Introduces a new flag called `--output` which specifies in which filepath to store the usns instead of outputing them on a variable.
* Removes logging the usns on the console.

That way we avoid hitting the `Argument list too long` error while running this action on a github workflow, when the usns list is too long.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
