### PR TITLE
Get last usns from a filepath

### DIFF
--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: '[]'
   last_usns_filepath:
-    description: 'JSimilar to last_usns, but instead of pointing into a variable, it points to a file'
+    description: 'Similar to last_usns, but instead of pointing into a variable, it points to a file'
     required: false
   packages:
     description: 'JSON array of stack package names'

--- a/actions/stack/get-usns/action.yml
+++ b/actions/stack/get-usns/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'JSON array of last known USNs'
     required: false
     default: '[]'
+  last_usns_filepath:
+    description: 'JSimilar to last_usns, but instead of pointing into a variable, it points to a file'
+    required: false
   packages:
     description: 'JSON array of stack package names'
     required: false
@@ -39,6 +42,8 @@ runs:
   - "${{ inputs.feed_url }}"
   - "--last-usns"
   - "${{ inputs.last_usns }}"
+  - "--last-usns-filepath"
+  - "${{ inputs.last_usns_filepath }}"
   - "--packages"
   - "${{ inputs.packages }}"
   - "--packages-filepath"

--- a/actions/stack/get-usns/entrypoint/main.go
+++ b/actions/stack/get-usns/entrypoint/main.go
@@ -48,6 +48,7 @@ func main() {
 	var config struct {
 		Distro               string
 		LastUSNsJSON         string
+		LastUSNsJSONFilepath string
 		Output               string
 		PackagesJSON         string
 		PackagesJSONFilepath string
@@ -59,6 +60,10 @@ func main() {
 		"last-usns",
 		"",
 		"JSON array of last known USNs")
+	flag.StringVar(&config.LastUSNsJSONFilepath,
+		"last-usns-filepath",
+		"",
+		"Filepath that points to the JSON array of last known USNs")
 	flag.StringVar(&config.RSSURL,
 		"feed-url",
 		"https://ubuntu.com/security/notices/rss.xml",
@@ -106,6 +111,19 @@ func main() {
 	err = json.Unmarshal([]byte(config.LastUSNsJSON), &lastUSNs)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if config.LastUSNsJSONFilepath != "" {
+
+		lastUSNsFilepath, err := os.ReadFile(config.LastUSNsJSONFilepath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.Unmarshal(lastUSNsFilepath, &lastUSNs)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	var packages []string


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds a new flag on the get-usns action called `last_usns_filepath` which enables the action to read the last usns from a file instead of a variable

It has been tested here https://github.com/pacostas/jammy-base-stack/actions/runs/14666445319/job/41162655763

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
