### PR TITLE
Removing installation of unused tool create-package

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -73,20 +73,18 @@ jobs:
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
-        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
       run: |
         jq --null-input \
            --sort-keys \
            --arg pack "${PACK_VERSION}" \
            --arg jam "${JAM_VERSION}" \
            --arg createpackage "${CREATE_PACKAGE_VERSION}" \
-           '{ pack: $pack, jam: $jam, createpackage: $createpackage }' > ./implementation/scripts/.util/tools.json
+           '{ pack: $pack, jam: $jam }' > ./implementation/scripts/.util/tools.json
 
     - name: Update language-family tools.json
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
-        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
       run: |
         jq --null-input \
            --sort-keys \

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -196,33 +196,6 @@ function util::tools::packager::install () {
     fi
 }
 
-function util::tools::create-package::install () {
-  local dir version
-    while [[ "${#}" != 0 ]]; do
-      case "${1}" in
-        --directory)
-          dir="${2}"
-          shift 2
-          ;;
-
-        *)
-          util::print::error "unknown argument \"${1}\""
-          ;;
-
-      esac
-    done
-
-    version="$(jq -r .createpackage "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
-
-    mkdir -p "${dir}"
-    util::tools::path::export "${dir}"
-
-    if [[ ! -f "${dir}/create-package" ]]; then
-      util::print::title "Installing create-package"
-      GOBIN="${dir}" go install -ldflags="-s -w" "github.com/paketo-buildpacks/libpak/cmd/create-package@${version}"
-    fi
-}
-
 function util::tools::tests::checkfocus() {
   testout="${1}"
   if grep -q 'Focused: [1-9]' "${testout}"; then

--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -110,9 +110,6 @@ function tools::install() {
     --directory "${BUILDPACKDIR}/.bin" \
     --token "${token}"
 
-  util::tools::create-package::install \
-    --directory "${BUILDPACKDIR}/.bin"
-
   if [[ -f "${BUILDPACKDIR}/.libbuildpack" ]]; then
     util::tools::packager::install \
       --directory "${BUILDPACKDIR}/.bin"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR removes the functionality of installing create-package on buildpacks.
The create-package is not being used for building the buildpacks, but jam is being used instead. 
Also, the latest major release breaks the installation of the tools.
For the aforementioned reasons I think its good to remove the installation of create-package.

## Use Cases
<!-- An explanation of the use cases your change enables -->


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
