### PR TITLE
Do not fail-fast, in case packages have been removed for some of the stacks

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -920,6 +920,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ !cancelled() && !failure() && needs.diff.result != 'skipped' }}
     strategy:
+      fail-fast: false
       matrix:
         stacks: ${{ fromJSON(needs.preparation.outputs.stacks) }}
         arch: ${{ fromJSON(needs.preparation.outputs.architectures) }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR changes the behavior of the step `packages_changed` on the create-release workflow so that it does not fail if some of the steps have failed. This will allow all the steps to run from the `packages_changed` step, giving that way a clear overview of each stack, and packages that changed.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
