### PR TITLE
Adding installation of create-package and libpak-tools

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -35,12 +35,12 @@ jobs:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         repo: buildpacks/pack
 
-    - name: Fetch Latest create-package
-      id: latest-create-package
+    - name: Fetch Latest libpak-tools
+      id: latest-libpak-tools
       uses: paketo-buildpacks/github-config/actions/tools/latest@main
       with:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-        repo: paketo-buildpacks/libpak
+        repo: paketo-buildpacks/libpak-tools
 
     - name: Fetch Latest syft
       id: latest-syft
@@ -58,9 +58,7 @@ jobs:
 
     - name: Update builder tools.json
       env:
-        JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
-        CREATE_PACKAGE_VERSION: ${{ steps.latest-create-package.outputs.version }}
         CRANE_VERSION: ${{ steps.latest-crane.outputs.version }}
       run: |
         jq --null-input \
@@ -73,13 +71,16 @@ jobs:
       env:
         JAM_VERSION: ${{ steps.latest-jam.outputs.version }}
         PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+        CREATE_PACKAGE_VERSION: "v1.73.0"
+        LIBPAK_TOOLS_VERSION: ${{ steps.latest-libpak-tools.outputs.version }}
       run: |
         jq --null-input \
            --sort-keys \
            --arg pack "${PACK_VERSION}" \
            --arg jam "${JAM_VERSION}" \
            --arg createpackage "${CREATE_PACKAGE_VERSION}" \
-           '{ pack: $pack, jam: $jam }' > ./implementation/scripts/.util/tools.json
+           --arg libpaktools "${LIBPAK_TOOLS_VERSION}" \
+           '{ pack: $pack, jam: $jam, createpackage: $createpackage, libpaktools: $libpaktools }' > ./implementation/scripts/.util/tools.json
 
     - name: Update language-family tools.json
       env:

--- a/implementation/scripts/.util/tools.json
+++ b/implementation/scripts/.util/tools.json
@@ -1,4 +1,6 @@
 {
+  "libpaktools": "v0.2.0",
+  "createpackage": "v1.73.0",
   "jam": "v2.11.5",
   "pack": "v0.38.1"
 }

--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -31,6 +31,8 @@ function util::tools::arch() {
     amd64|x86_64)
       if [[ "${1:-}" == "--blank-amd64" ]]; then
         echo ""
+      elif [[ "${1:-}" == "--format-amd64-x86_64" ]]; then
+        echo "x86_64"
       else
         echo "amd64"
       fi
@@ -193,6 +195,91 @@ function util::tools::packager::install () {
     if [[ ! -f "${dir}/packager" ]]; then
       util::print::title "Installing packager"
       GOBIN="${dir}" go install github.com/cloudfoundry/libcfbuildpack/packager@latest
+    fi
+}
+
+function util::tools::libpak-tools::install () {
+  local dir token
+  token=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --directory)
+        dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
+        shift 2
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  mkdir -p "${dir}"
+  util::tools::path::export "${dir}"
+
+
+  if [[ ! -f "${dir}/libpak-tools" ]]; then
+    local version curl_args os arch
+
+    version="$(jq -r .libpaktools "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
+
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/libpak-tools.tar.gz"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+    util::print::title "Installing libpak-tools ${version}"
+
+    os=$(util::tools::os)
+    arch=$(util::tools::arch --format-amd64-x86_64)
+
+    curl "https://github.com/paketo-buildpacks/libpak-tools/releases/download/${version}/libpak-tools_${os^}_${arch}.tar.gz" \
+      "${curl_args[@]}"
+
+    tar -xzf "${dir}/libpak-tools.tar.gz" -C $dir
+    rm "${dir}/libpak-tools.tar.gz"
+
+    chmod +x "${dir}/libpak-tools"
+  else
+    util::print::info "Using libpak-tools"
+  fi
+}
+
+function util::tools::create-package::install () {
+  local dir version
+    while [[ "${#}" != 0 ]]; do
+      case "${1}" in
+        --directory)
+          dir="${2}"
+          shift 2
+          ;;
+
+        *)
+          util::print::error "unknown argument \"${1}\""
+          ;;
+
+      esac
+    done
+
+    version="$(jq -r .createpackage "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
+
+    mkdir -p "${dir}"
+    util::tools::path::export "${dir}"
+
+    if [[ ! -f "${dir}/create-package" ]]; then
+      util::print::title "Installing create-package"
+      GOBIN="${dir}" go install -ldflags="-s -w" "github.com/paketo-buildpacks/libpak/cmd/create-package@${version}"
     fi
 }
 

--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -110,6 +110,12 @@ function tools::install() {
     --directory "${BUILDPACKDIR}/.bin" \
     --token "${token}"
 
+  util::tools::libpak-tools::install \
+    --directory "${BUILDPACKDIR}/.bin"
+
+  util::tools::create-package::install \
+    --directory "${BUILDPACKDIR}/.bin"
+
   if [[ -f "${BUILDPACKDIR}/.libbuildpack" ]]; then
     util::tools::packager::install \
       --directory "${BUILDPACKDIR}/.bin"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR reverts the previous PR https://github.com/paketo-buildpacks/github-config/pull/1056 by adding back the create-package and pinning to the latest version where occam was compatible with to use it. It also adds the libpak-tools CLI. This revert is necessary as in some buildpacks it blocks further PRs from the github-config https://github.com/paketo-buildpacks/npm-start/pull/674/files.

The issue is that occam references createpackage in some of the integration tests, mostly for packaging watchexec, see list below :
* https://github.com/search?q=org%3Apaketo-buildpacks%20packagers.NewLibpak&type=code

We also pin the create-package to version 1.73.0 due to occam breaks with the version 2.0.0. For this reason, I've opened a PR https://github.com/paketo-buildpacks/occam/pull/394 that is able to package watchexec on the integration tests by using libpak 2.0.0 https://github.com/paketo-buildpacks/libpak which practically is libpak-tools 0.2.0  https://github.com/paketo-buildpacks/libpak-tools 

The plan is to once both github-config and occam has been landed and upgraded to these repos https://github.com/paketo-buildpacks/npm-start/pull/674/files to revert the reverted PR https://github.com/paketo-buildpacks/github-config/pull/1056 which removes the createpackage.


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
