### PR TITLE
Change Renovate users

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,6 +1,6 @@
 module.exports = {
     username: 'renovate-release',
-    gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
+    gitAuthor: 'paketo-bot <paketobuildpacks@gmail.com>',
     onboarding: false,
     platform: 'github',
     forkProcessing: 'enabled',

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,6 @@ jobs:
       uses: renovatebot/github-action@v42.0.3
       with:
         configurationFile: ./.github/renovate-config.js
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       env:
         LOG_LEVEL: 'debug'


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
User "Renovate Bot" is not configured to comply with Linux CLA. Instead, user "paketo-bot" should open PRs and subscribe commits for dependency updates.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
