### PR TITLE
Handle depth -1 because jq-1.8 does not anymore support -1 on limit()

### DIFF
--- a/actions/release/find-asset/entrypoint
+++ b/actions/release/find-asset/entrypoint
@@ -54,21 +54,37 @@ function find_asset() {
   pattern="${3}"
   strict="${4}"
 
-  release_json=$(gh api "repos/${repo}/releases?per_page=100"  \
-    --method GET \
-    --paginate \
-    | jq -s '[.[]]' \
-    | jq 'add' \
-    | jq -r \
-    --arg pattern "${pattern}" \
-    --argjson depth "${depth}" \
-    'sort_by(.tag_name | gsub("^v"; "")  | split(".") | map(tonumber))
-    | reverse
-    | map(select(.draft==false))
-    | limit($depth; .)
-    | map(select(.assets | .[] | select(.name | test($pattern))))
-    | .[0]' \
-  )
+  if [ "${depth}" == "-1" ]; then
+    release_json=$(gh api "repos/${repo}/releases?per_page=100"  \
+      --method GET \
+      --paginate \
+      | jq -s '[.[]]' \
+      | jq 'add' \
+      | jq -r \
+      --arg pattern "${pattern}" \
+      'sort_by(.tag_name | gsub("^v"; "")  | split(".") | map(tonumber))
+      | reverse
+      | map(select(.draft==false))
+      | map(select(.assets | .[] | select(.name | test($pattern))))
+      | .[0]' \
+    )
+  else
+    release_json=$(gh api "repos/${repo}/releases?per_page=100"  \
+      --method GET \
+      --paginate \
+      | jq -s '[.[]]' \
+      | jq 'add' \
+      | jq -r \
+      --arg pattern "${pattern}" \
+      --argjson depth "${depth}" \
+      'sort_by(.tag_name | gsub("^v"; "")  | split(".") | map(tonumber))
+      | reverse
+      | map(select(.draft==false))
+      | limit($depth; .)
+      | map(select(.assets | .[] | select(.name | test($pattern))))
+      | .[0]' \
+    )
+  fi
 
   if [[ "${release_json}" == "null" ]]; then
       echo "No matching asset found for pattern: '${pattern}' on repo: '${repo}' and depth: '${depth}'."


### PR DESCRIPTION
## Summary

jq 1.8 made a change to the `limit()` function, passing -1 to n is not allowed anymore. See https://github.com/jqlang/jq/blob/jq-1.7.1/src/builtin.jq#L149-L152 vs https://github.com/jqlang/jq/blob/jq-1.8.0/src/builtin.jq#L142-L145

This PR changes the `find_asset()` function to omit the call `limit`.

Tried it out:

```sh
$ GITHUB_OUTPUT=/tmp/out ./entrypoint --repo paketo-buildpacks/jammy-full-stack --pattern '\d+.\d+(.\d+)?-patched-usns.json' --depth 10 --strict false
github.com
  ✓ Logged in to github.com account SaschaSchwarze0 (GITHUB_TOKEN)
[...]
Found asset: 'jammy-full-stack-0.1.90-patched-usns.json' on repo: 'paketo-buildpacks/jammy-full-stack' version: 'v0.1.90'.
Asset URL: https://api.github.com/repos/paketo-buildpacks/jammy-full-stack/releases/assets/270918610
url=https://api.github.com/repos/paketo-buildpacks/jammy-full-stack/releases/assets/270918610


$ GITHUB_OUTPUT=/tmp/out ./entrypoint --repo paketo-buildpacks/jammy-full-stack --pattern '\d+.\d+(.\d+)?-patched-usns.json' --depth -1 --strict false
github.com
  ✓ Logged in to github.com account SaschaSchwarze0 (GITHUB_TOKEN)
[...]
Found asset: 'jammy-full-stack-0.1.90-patched-usns.json' on repo: 'paketo-buildpacks/jammy-full-stack' version: 'v0.1.90'.
Asset URL: https://api.github.com/repos/paketo-buildpacks/jammy-full-stack/releases/assets/270918610
url=https://api.github.com/repos/paketo-buildpacks/jammy-full-stack/releases/assets/270918610
```

## Use Cases

This should fix https://github.com/paketo-buildpacks/jammy-full-stack/actions/runs/16585667796/job/46910281636

Related slack thread: https://paketobuildpacks.slack.com/archives/C03K61JJ57A/p1753683465747749

## Checklist

* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
