### PR TITLE
Add multi arch support for implementation buildpacks

### DIFF
--- a/implementation/.github/workflows/compile-dependency.yml
+++ b/implementation/.github/workflows/compile-dependency.yml
@@ -1,0 +1,106 @@
+name: 'Compile Dependency on Target - Reusable Workflow'
+
+description: |
+  Compiles Dependency on given target, os, and arch
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'dependency version'
+        required: true
+        type: string
+      target:
+        description: 'dependency OS target variant'
+        required: true
+        type: string
+      os:
+        description: 'platform OS (e.g., linux)'
+        required: true
+        type: string
+      arch:
+        description: 'platform architecture (e.g., amd64)'
+        required: true
+        type: string
+      shouldCompile:
+        description: 'whether to compile the dependency'
+        required: true
+        type: boolean
+      shouldTest:
+        description: 'whether to test the dependency after compilation'
+        required: true
+        type: boolean
+      uploadArtifactName:
+        description: 'name of the artifact to upload'
+        required: true
+        type: string
+
+jobs:
+  compile:
+    # Speed up compilation by using runners that match os and arch when they are set, otherwise fall back to emulation.
+    runs-on: ${{ (inputs.os == 'linux' && inputs.arch == 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Enable experimental features for Docker daemon and CLI
+      run: |
+        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+        mkdir -p ~/.docker
+        echo '{"experimental": "enabled"}' | sudo tee ~/.docker/config.json
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Setup before compilation
+      id: compile-setup
+      run: |
+        echo "outputdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
+
+    - name: docker build
+      id: docker-build
+      env:
+        SKIP_LOGIN: true
+      if: ${{ inputs.shouldCompile == true || inputs.shouldCompile == 'true' }}
+      uses: actions-hub/docker/cli@master
+      with:
+        args: "build ${{ (inputs.os != '' && inputs.arch != '') && format('--platform {0}/{1}', inputs.os, inputs.arch) || '' }} -t compilation -f dependency/actions/compile/${{ inputs.target }}.Dockerfile dependency/actions/compile"
+
+    - name: docker run
+      id: docker-run
+      uses: actions-hub/docker/cli@master
+      env:
+        SKIP_LOGIN: true
+      if: ${{ inputs.shouldCompile == true || inputs.shouldCompile == 'true' }}
+      with:
+        args: "run ${{ (inputs.os != '' && inputs.arch != '') && format('--platform {0}/{1}', inputs.os, inputs.arch) || '' }} -v ${{ steps.compile-setup.outputs.outputdir }}:/home compilation --outputDir /home --target ${{ inputs.target }} --version ${{ inputs.version }} ${{ inputs.os != '' && format('--os {0}', inputs.os) || '' }} ${{ inputs.arch != '' && format('--arch {0}', inputs.arch) || '' }}"
+
+    - name: Print contents of output dir
+      shell: bash
+      run: ls -lah ${{ steps.compile-setup.outputs.outputdir }}
+
+    - name: Test Dependency
+      working-directory: dependency
+      if: ${{ (inputs.shouldCompile == true || inputs.shouldCompile == 'true') && (inputs.shouldTest == true || inputs.shouldTest == 'true') }}
+      run: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        shopt -s inherit_errexit
+
+        make test \
+          version="${{ inputs.version }}" \
+          tarballPath="${{ steps.compile-setup.outputs.outputdir }}/*.tgz" \
+          os="${{ inputs.os }}" \
+          arch="${{ inputs.arch }}"
+
+    - name: Upload compiled artifact
+      uses: actions/upload-artifact@v4
+      if: ${{ inputs.shouldCompile == true || inputs.shouldCompile == 'true' }}
+      with:
+        name: '${{ inputs.uploadArtifactName }}'
+        path: '${{ steps.compile-setup.outputs.outputdir }}/*'

--- a/implementation/.github/workflows/create-draft-release.yml
+++ b/implementation/.github/workflows/create-draft-release.yml
@@ -61,6 +61,12 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     needs: integration
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -110,6 +116,16 @@ jobs:
           echo "buildpack_type=buildpack" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Get buildpack path
+      id: get_buildpack_path
+      run: |
+
+        if [ -f "build/buildpackage.cnb" ]; then
+          echo "path=build/buildpackage.cnb" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=build/buildpackage-linux-amd64.cnb" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Create Release Notes
       id: create-release-notes
       uses: paketo-buildpacks/github-config/actions/release/notes@main
@@ -117,6 +133,69 @@ jobs:
         repo: ${{ github.repository }}
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         buildpack_type: ${{ steps.get_buildpack_type.outputs.buildpack_type }}
+        buildpackage_path: ${{ steps.get_buildpack_path.outputs.path }}
+
+    - name: Get Image Digest
+      id: image_digest
+      run: |
+        image_name="localhost:5000/npm-install:latest"
+
+        ./scripts/publish.sh \
+          --buildpack-type ${{ steps.get_buildpack_type.outputs.buildpack_type }} \
+          --image-ref $image_name
+
+        echo "digest=$(sudo skopeo inspect "docker://${image_name}" --tls-verify=false | jq -r .Digest)" >> "$GITHUB_OUTPUT"
+
+    - name: Set Correct Image Digest on the Release notes
+      run: |
+          printf '${{ steps.create-release-notes.outputs.release_body }}' \
+            | sed -E \
+              "s/\*\*Digest:\*\* \`sha256:[a-f0-9]{64}\`/\*\*Digest:\*\* \`${{ steps.image_digest.outputs.digest }}\`/" \
+              > ./release_notes
+
+          printf '${{ steps.image_digest.outputs.digest }}' > ./index-digest.sha256
+
+    - name: Create release assets
+      id: create_release_assets
+      run: |
+        release_assets=$(jq -n --arg repo_name "${{ github.event.repository.name }}" --arg tag "${{ steps.tag.outputs.tag }}" '
+        [
+          {
+            "path": "build/buildpack.tgz",
+            "name": ($repo_name + "-" + $tag + ".tgz"),
+            "content_type": "application/gzip"
+          },
+          {
+            "path": "./index-digest.sha256",
+            "name": ($repo_name + "-" + $tag + "-" + "index-digest.sha256"),
+            "content_type": "text/plain"
+          }
+        ]')
+
+        for filepath in build/*.cnb; do
+          filename=$(basename "$filepath")
+          asset_name=""
+          if [[ "$filename" == "buildpackage-linux-amd64.cnb" ]]; then
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb"
+          elif [[ "$filename" == "buildpackage.cnb" ]]; then
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb"
+          else
+            formatted_filename="${filename#buildpackage-}"
+            asset_name="${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}-${formatted_filename}"
+          fi
+
+          release_assets=$(echo "$release_assets" | jq --arg asset_name "${asset_name}" --arg filepath "$filepath" '
+          . + [
+            {
+              "path": $filepath,
+              "name": $asset_name,
+              "content_type": "application/gzip"
+            }
+          ]')
+        done
+
+        release_assets=$(jq -c <<< "$release_assets" )
+        printf "release_assets=%s\n" "${release_assets}" >> "$GITHUB_OUTPUT"
 
     - name: Create Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
@@ -126,21 +205,9 @@ jobs:
         tag_name: v${{ steps.tag.outputs.tag }}
         target_commitish: ${{ github.sha }}
         name: v${{ steps.tag.outputs.tag }}
-        body: ${{ steps.create-release-notes.outputs.release_body }}
+        body_filepath: "./release_notes"
         draft: true
-        assets: |
-          [
-            {
-              "path": "build/buildpack.tgz",
-              "name": "${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.tgz",
-              "content_type": "application/gzip"
-            },
-            {
-              "path": "build/buildpackage.cnb",
-              "name": "${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.cnb",
-              "content_type": "application/gzip"
-            }
-          ]
+        assets: ${{ steps.create_release_assets.outputs.release_assets }}
 
   failure:
     name: Alert on Failure

--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
     - published
+
 env:
   REGISTRIES_FILENAME: "registries.json"
 
@@ -11,6 +12,14 @@ jobs:
   push:
     name: Push
     runs-on: ubuntu-24.04
+    env:
+      GCR_REGISTRY: "gcr.io"
+      GCR_PASSWORD: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+      GCR_USERNAME: "_json_key"
+      DOCKERHUB_REGISTRY: docker.io
+      DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+
     steps:
 
     - name: Checkout
@@ -25,14 +34,29 @@ jobs:
         echo "tag_full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
         echo "tag_minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
         echo "tag_major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-        echo "download_url=$(jq -r '.release.assets[] | select(.name | endswith(".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_tgz_file_url=$(jq -r '.release.assets[] | select(.name | endswith(".tgz")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_cnb_file_url=$(jq -r --arg tag_full "$FULL_VERSION" '.release.assets[] | select(.name | endswith($tag_full + ".cnb")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "download_sha256_file_url=$(jq -r '.release.assets[] | select(.name | endswith("index-digest.sha256")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
-    - name: Download
-      id: download
+    - name: Download .cnb buildpack
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
       with:
-        url: ${{ steps.event.outputs.download_url }}
+        url: ${{ steps.event.outputs.download_cnb_file_url }}
         output: "/github/workspace/buildpackage.cnb"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download .tgz buildpack
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.download_tgz_file_url }}
+        output: "/github/workspace/buildpack.tgz"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download .sha digest
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.download_sha256_file_url }}
+        output: "/github/workspace/index-digest.sha256"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
     - name: Parse Configs
@@ -64,41 +88,74 @@ jobs:
           exit 1
         fi
 
-    - name: Push to GCR
-      if: ${{  steps.parse_configs.outputs.push_to_gcr == 'true' }}
-      env:
-        GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+    - name: Get buildpack type
+      id: get_buildpack_type
       run: |
-        echo "${GCR_PUSH_BOT_JSON_KEY}" | sudo skopeo login --username _json_key --password-stdin gcr.io
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_full }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_minor }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:${{ steps.event.outputs.tag_major }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://gcr.io/${{ github.repository }}:latest"
+        if [ -f "extension.toml" ]; then
+          echo "buildpack_type=extension" >> "$GITHUB_OUTPUT"
+        else
+          echo "buildpack_type=buildpack" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Docker login docker.io
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
+        registry: ${{ env.DOCKERHUB_REGISTRY }}
+
+    - name: Docker login gcr.io
+      uses: docker/login-action@v3
+      if: ${{ steps.parse_configs.outputs.push_to_gcr == 'true' }}
+      with:
+        username: ${{ env.GCR_USERNAME }}
+        password: ${{ env.GCR_PASSWORD }}
+        registry: ${{ env.GCR_REGISTRY }}
 
     - name: Push to DockerHub
       if: ${{  steps.parse_configs.outputs.push_to_dockerhub == 'true' }}
       id: push
       env:
-        DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
-        DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       run: |
-        REPOSITORY="${GITHUB_REPOSITORY_OWNER/-/}/${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" # translates 'paketo-buildpacks/bundle-install' to 'paketobuildpacks/bundle-install'
-        IMAGE="index.docker.io/${REPOSITORY}"
-        echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin index.docker.io
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_full }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_minor }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:${{ steps.event.outputs.tag_major }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" "docker://${IMAGE}:latest"
+        IMAGE="${GITHUB_REPOSITORY_OWNER/-/}/${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" # translates 'paketo-buildpacks/bundle-install' to 'paketobuildpacks/bundle-install'
+        echo "${DOCKERHUB_PASSWORD}" | sudo skopeo login --username "${DOCKERHUB_USERNAME}" --password-stdin ${DOCKERHUB_REGISTRY}
+
+        ./scripts/publish.sh \
+          --archive-path ./buildpack.tgz \
+          --buildpack-type ${{ steps.get_buildpack_type.outputs.buildpack_type }} \
+          --image-ref "${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}"
+
+        ## Validate that the digest pushed to registry matches with the one mentioned on the readme file
+        pushed_image_index_digest=$(sudo skopeo inspect "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" | jq -r .Digest)
+
+        if [ "$(cat ./index-digest.sha256)" != "$pushed_image_index_digest" ]; then
+          echo "Image index digest pushed to registry does not match with the one mentioned on the readme file"
+          exit 1;
+        fi
+
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_minor }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_major }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:latest" --multi-arch all
         echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-        echo "digest=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)" >> "$GITHUB_OUTPUT"
+        echo "digest=$pushed_image_index_digest" >> "$GITHUB_OUTPUT"
+
+    - name: Push to GCR
+      if: ${{ steps.parse_configs.outputs.push_to_gcr == 'true' }}
+      run: |
+        echo "${GCR_PASSWORD}" | sudo skopeo login --username "${GCR_USERNAME}" --password-stdin "${GCR_REGISTRY}"
+
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_full }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_minor }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:${{ steps.event.outputs.tag_major }}" --multi-arch all
+        sudo skopeo copy "docker://${DOCKERHUB_REGISTRY}/${{ steps.push.outputs.image }}" "docker://${GCR_REGISTRY}/${{ github.repository }}:latest" --multi-arch all
 
     - name: Register with CNB Registry
       uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:main
       with:
         id: ${{ github.repository }}
         version: ${{ steps.event.outputs.tag_full }}
-        address: ${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
+        address: index.docker.io/${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
   failure:

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -63,7 +63,6 @@ jobs:
           printf "compilation-json<<%s\n%s\n%s\n" "${delimiter}" "${compilation}" "${delimiter}" >> "$GITHUB_OUTPUT" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           echo "compilation-length=$complength" >> "$GITHUB_OUTPUT"
 
-
       - name: Upload `${{ steps.retrieve.outputs.metadata-filepath }}`
         uses: actions/upload-artifact@v4
         with:
@@ -168,50 +167,15 @@ jobs:
     #   AND:
     #   (3) there is at least one version to compile/test
     if: ${{ needs.retrieve.outputs.compilation-length > 0 && (needs.get-compile-and-test.outputs.should-compile == 'true' || needs.get-compile-and-test.outputs.should-test == 'true') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Make Temporary Artifact Directory
-        id: make-outputdir
-        run: |
-          echo "outputdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
-
-      # Compile if all of the following conditions are met:
-      #   (1) compilation Github Action presetn in the buildpack directory
-      #   (2) checksum in metadata.json is empty
-      #   (3) URI in metadata.json is empty
-      - name: Compile version ${{ matrix.includes.version }} on ${{ matrix.includes.target }} Dockerfile
-        id: compile
-        if: ${{ needs.get-compile-and-test.outputs.should-compile && matrix.includes.checksum == '' && matrix.includes.uri == '' }}
-        uses: ./dependency/actions/compile
-        with:
-          version: "${{ matrix.includes.version }}"
-          outputdir: "${{ steps.make-outputdir.outputs.outputdir }}"
-          target: "${{ matrix.includes.target }}"
-
-      # If compiled, upload the tarball and checksum file for usage in the Update metadata job
-      - name: Upload workflow asset
-        uses: actions/upload-artifact@v4
-        if: ${{ needs.get-compile-and-test.outputs.should-compile && matrix.includes.checksum == '' && matrix.includes.uri == '' }}
-        with:
-          name: '${{ needs.retrieve.outputs.id }}-${{ matrix.includes.version }}-${{ matrix.includes.target }}'
-          path: '${{ steps.make-outputdir.outputs.outputdir }}/*'
-
-      # Test the dependency tarball if:
-      #   (1) dependency testing code is present in the buildpack directory
-      - name: Test Dependency
-        working-directory: dependency
-        if: ${{ needs.get-compile-and-test.outputs.should-test == 'true' }}
-        run: |
-          #!/usr/bin/env bash
-          set -euo pipefail
-          shopt -s inherit_errexit
-
-          make test \
-            version="${{ matrix.includes.version }}" \
-            tarballPath="${{ steps.make-outputdir.outputs.outputdir }}/*.tgz"
+    uses: ./.github/workflows/compile-dependency.yml
+    with:
+      version: "${{ matrix.includes.version }}"
+      target: "${{ matrix.includes.target }}"
+      os: "${{ matrix.includes.os }}"
+      arch: "${{ matrix.includes.arch }}"
+      shouldCompile: ${{ matrix.includes.checksum == '' && matrix.includes.uri == '' }}
+      shouldTest: ${{ matrix.includes.checksum == '' && matrix.includes.uri == '' && needs.get-compile-and-test.outputs.should-test == 'true' }}
+      uploadArtifactName: "${{ needs.retrieve.outputs.id }}-${{ matrix.includes.version }}-${{ matrix.includes.os != '' && matrix.includes.os || 'linux' }}-${{ matrix.includes.arch != '' && matrix.includes.arch || 'amd64' }}-${{ matrix.includes.target }}"
 
   # Add in the checksum and URI fields to the metadata if the dependency was compiled
   update-metadata:
@@ -232,7 +196,7 @@ jobs:
       - name: Download artifact files
         uses: actions/download-artifact@v4
         with:
-          name: '${{ needs.retrieve.outputs.id }}-${{ matrix.includes.version }}-${{ matrix.includes.target }}'
+          name: "${{ needs.retrieve.outputs.id }}-${{ matrix.includes.version }}-${{ matrix.includes.os != '' && matrix.includes.os || 'linux' }}-${{ matrix.includes.arch != '' && matrix.includes.arch || 'amd64' }}-${{ matrix.includes.target }}"
 
       - name: Get artifact file name
         id: get-file-names
@@ -277,8 +241,13 @@ jobs:
           set -euo pipefail
           shopt -s inherit_errexit
 
-          metadata_file_name="${{ matrix.includes.target }}-${{ matrix.includes.version }}-metadata-file.json"
-          cat metadata.json | jq -r ['.[] | select( .version == "${{ matrix.includes.version }}" and .target == "${{ matrix.includes.target }}")'] > $metadata_file_name
+          metadata_file_name="${{ matrix.includes.target }}-${{ matrix.includes.version }}-${{ matrix.includes.os != '' && matrix.includes.os || 'linux' }}-${{ matrix.includes.arch != '' && matrix.includes.arch || 'amd64' }}-metadata-file.json"
+          if [[ -z "${{ matrix.includes.os }}" && -z "${{ matrix.includes.arch }}" ]]; then
+            cat metadata.json | jq -r ['.[] | select( .version == "${{ matrix.includes.version }}" and .target == "${{ matrix.includes.target }}")'] > $metadata_file_name
+          else
+            echo "multi-arch buildpack with os and arch specified"
+            cat metadata.json | jq -r ['.[] | select( .version == "${{ matrix.includes.version }}" and .target == "${{ matrix.includes.target }}" and .os == "${{ matrix.includes.os }}" and .arch == "${{ matrix.includes.arch }}")'] > $metadata_file_name
+          fi
           echo "file=$(echo $metadata_file_name)" >> "$GITHUB_OUTPUT"
 
       - name: Update `checksum` and `uri` in metadata for ${{ matrix.includes.target }} ${{ matrix.includes.version }}
@@ -290,6 +259,8 @@ jobs:
           checksum: ${{ steps.get-checksum.outputs.checksum }}
           uri: ${{ steps.upload.outputs.dependency-uri }}
           file: ${{ steps.dependency-metadata.outputs.file }}
+          os: ${{ matrix.includes.os }}
+          arch: ${{ matrix.includes.arch }}
 
       - name: Upload modified metadata
         uses: actions/upload-artifact@v4

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -355,7 +355,7 @@ jobs:
         with:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
           title: "Updates buildpack.toml with ${{ steps.update.outputs.new-versions }}"
-          branch: automation/buildpack.toml/update-from-metadata
+          branch: automation/dependencies/update-from-metadata
 
   failure:
     name: Alert on Failure

--- a/implementation/scripts/build.sh
+++ b/implementation/scripts/build.sh
@@ -3,16 +3,26 @@
 set -eu
 set -o pipefail
 
+readonly ROOT_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOT_DIR}/scripts/.util/print.sh"
+
 function main() {
+  local targets=()
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
       --help|-h)
         shift 1
         usage
         exit 0
+        ;;
+
+      --target)
+        targets+=("${2}")
+        shift 2
         ;;
 
       "")
@@ -27,8 +37,18 @@ function main() {
 
   mkdir -p "${BUILDPACKDIR}/bin"
 
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=("linux/amd64")
+    util::print::info "Setting default target platform architecture to: linux/amd64"
+  fi
+
   run::build
   cmd::build
+
+  ## For backwards compatibility with amd64 wokflows
+  if [[ ${#targets[@]} -eq 1 && "${targets[0]}" == "linux/amd64" ]]; then
+    cp -r "${BUILDPACKDIR}/linux/amd64/bin/" "${BUILDPACKDIR}/"
+  fi
 }
 
 function usage() {
@@ -38,39 +58,49 @@ build.sh [OPTIONS]
 Builds the buildpack executables.
 
 OPTIONS
-  --help  -h  prints the command usage
+  --target strings  Target platforms to build for.
+                    Targets should be in the format '[os][/arch][/variant]'.
+                      - To specify two different architectures: '--target "linux/amd64" --target "linux/arm64"'
+  --help  -h        prints the command usage
 USAGE
 }
 
 function run::build() {
   if [[ -f "${BUILDPACKDIR}/run/main.go" ]]; then
-    pushd "${BUILDPACKDIR}/bin" > /dev/null || return
-      printf "%s" "Building run... "
+    pushd "${BUILDPACKDIR}" > /dev/null || return
+      for target in "${targets[@]}"; do
+        platform=$(echo "${target}" | cut -d '/' -f1)
+        arch=$(echo "${target}" | cut -d'/' -f2)
 
-      GOOS=linux \
-      CGO_ENABLED=0 \
-        go build \
-          -ldflags="-s -w" \
-          -o "run" \
-            "${BUILDPACKDIR}/run"
+        util::print::title "Building run... for platform: ${platform} and arch: ${arch}"
 
-      echo "Success!"
+        GOOS=$platform \
+        GOARCH=$arch \
+        CGO_ENABLED=0 \
+          go build \
+            -ldflags="-s -w" \
+            -o "${platform}/${arch}/bin/run" \
+              "${BUILDPACKDIR}/run"
 
-      names=("detect")
+          echo "Success!"
 
-      if [ -f "${BUILDPACKDIR}/extension.toml" ]; then
-        names+=("generate")
-      else
-        names+=("build")
-      fi
+          names=("detect")
 
-      for name in "${names[@]}"; do
-        printf "%s" "Linking ${name}... "
+          if [ -f "${BUILDPACKDIR}/extension.toml" ]; then
+            names+=("generate")
+          else
+            names+=("build")
+          fi
 
-        ln -sf "run" "${name}"
+        for name in "${names[@]}"; do
+          printf "%s" "Linking ${name}... "
 
-        echo "Success!"
+          ln -fs "run" "${platform}/${arch}/bin/${name}"
+
+          echo "Success!"
+        done
       done
+
     popd > /dev/null || return
   fi
 }
@@ -80,21 +110,26 @@ function cmd::build() {
     local name
     for src in "${BUILDPACKDIR}"/cmd/*; do
       name="$(basename "${src}")"
+      for target in "${targets[@]}"; do
+        platform=$(echo "${target}" | cut -d '/' -f1)
+        arch=$(echo "${target}" | cut -d'/' -f2)
 
-      if [[ -f "${src}/main.go" ]]; then
-        printf "%s" "Building ${name}... "
+        if [[ -f "${src}/main.go" ]]; then
+          util::print::title "Building ${name}... for platform: ${platform} and arch: ${arch}"
 
-        GOOS="linux" \
-        CGO_ENABLED=0 \
-          go build \
-            -ldflags="-s -w" \
-            -o "${BUILDPACKDIR}/bin/${name}" \
-              "${src}/main.go"
+          GOOS=$platform \
+          GOARCH=$arch \
+          CGO_ENABLED=0 \
+            go build \
+              -ldflags="-s -w" \
+              -o "${BUILDPACKDIR}/${platform}/${arch}/bin/${name}" \
+                "${src}/main.go"
 
-        echo "Success!"
-      else
-        printf "%s" "Skipping ${name}... "
-      fi
+          echo "Success!"
+        else
+          printf "%s" "Skipping ${name}... "
+        fi
+      done
     done
   fi
 }

--- a/implementation/scripts/package.sh
+++ b/implementation/scripts/package.sh
@@ -144,26 +144,15 @@ function buildpackage::create() {
 
   util::print::title "Packaging ${buildpack_type}... ${output}"
 
-  if [ "$buildpack_type" == "extension" ]; then
-    cwd=$(pwd)
-    cd ${BUILD_DIR}
-    mkdir cnbdir
-    cd cnbdir
-    cp ../buildpack.tgz .
-    tar -xvf buildpack.tgz
-    rm buildpack.tgz
+  mkdir ${BUILD_DIR}/cnbdir
+  tar -xvf ${BUILD_DIR}/buildpack.tgz -C ${BUILD_DIR}/cnbdir
 
-    pack \
-      extension package "${output}" \
-        --format file
+  pack \
+    "${buildpack_type}" package "${output}" \
+      --path ${BUILD_DIR}/cnbdir \
+      --format file
 
-    cd $cwd
-  else
-    pack \
-      buildpack package "${output}" \
-        --path "${BUILD_DIR}/buildpack.tgz" \
-        --format file
-  fi
+  rm -rf ${BUILD_DIR}/cnbdir
 }
 
 main "${@:-}"

--- a/implementation/scripts/publish.sh
+++ b/implementation/scripts/publish.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+readonly ROOT_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
+readonly BIN_DIR="${ROOT_DIR}/.bin"
+
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${ROOT_DIR}/scripts/.util/tools.sh"
+
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOT_DIR}/scripts/.util/print.sh"
+
+function main {
+  local archive_path buildpack_type image_ref token
+  token=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+    --archive-path | -a)
+      archive_path="${2}"
+      shift 2
+      ;;
+
+    --buildpack-type | -bt)
+      buildpack_type="${2}"
+      shift 2
+      ;;
+
+    --image-ref | -i)
+      image_ref+=("${2}")
+      shift 2
+      ;;
+
+    --token | -t)
+      token="${2}"
+      shift 2
+      ;;
+
+    --help | -h)
+      shift 1
+      usage
+      exit 0
+      ;;
+
+    "")
+      # skip if the argument is empty
+      shift 1
+      ;;
+
+    *)
+      util::print::error "unknown argument \"${1}\""
+      ;;
+    esac
+  done
+
+  if [[ -z "${image_ref:-}" ]]; then
+    usage
+    util::print::error "--image-ref is required"
+  fi
+
+  if [[ -z "${buildpack_type:-}" ]]; then
+    usage
+    util::print::error "--buildpack-type is required"
+  fi
+
+  if [[ ${buildpack_type} != "buildpack" && ${buildpack_type} != "extension" ]]; then
+    usage
+    util::print::error "--buildpack-type accepted values: [\"buildpack\",\"extension\"]"
+  fi
+
+  if [[ -z "${archive_path:-}" ]]; then
+    util::print::info "Using default archive path: ${ROOT_DIR}/build/buildpack.tgz"
+    archive_path="${ROOT_DIR}/build/buildpack.tgz"
+  else
+    archive_path="${archive_path}"
+  fi
+
+  repo::prepare
+
+  tools::install "${token}"
+
+  buildpack::publish "${image_ref}" "${buildpack_type}" "${archive_path}"
+}
+
+function usage() {
+  cat <<-USAGE
+Publishes a buildpack or an extension in to a registry.
+
+OPTIONS
+  -a, --archive-path <filepath>       Path to the buildpack or extension arhive (default: ${ROOT_DIR}/build/buildpack.tgz) (optional)
+  -h, --help                          Prints the command usage
+  -i, --image-ref <ref>               List of image reference to publish to (required)
+  -bt --buildpack-type <string>       Type of buildpack to publish (accepted values: buildpack, extension) (required)
+  -t, --token <token>                 Token used to download assets from GitHub (e.g. jam, pack, etc) (optional)
+
+USAGE
+}
+
+function repo::prepare() {
+  util::print::title "Preparing repo..."
+
+  mkdir -p "${BIN_DIR}"
+
+  export PATH="${BIN_DIR}:${PATH}"
+}
+
+function tools::install() {
+  local token
+  token="${1}"
+
+  util::tools::pack::install \
+    --directory "${BIN_DIR}" \
+    --token "${token}"
+}
+
+function buildpack::publish() {
+
+  local image_ref buildpack_type archive_path
+  image_ref="${1}"
+  buildpack_type="${2}"
+  archive_path="${3}"
+
+  util::print::title "Publishing ${buildpack_type}..."
+
+  util::print::info "Extracting archive..."
+  tmp_dir=$(mktemp -d -p $ROOT_DIR)
+  tar -xvf $archive_path -C $tmp_dir
+
+  util::print::info "Publishing ${buildpack_type} to ${image_ref}"
+
+  pack \
+    ${buildpack_type} package $image_ref \
+    --path $tmp_dir \
+    --format image \
+    --publish
+
+  rm -rf $tmp_dir
+}
+
+main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR updates implementation buildpacks to support multi-arch. All changes are backward compatible so existing single-architecture buildpacks are supported without any changes.

The first commit updates the scripts and workflows used to build, package, publish, and create draft releases.

The second commit adds a new reusable workflow for compiling dependencies and updates the `update-dependencies-from-metadata.yml` workflow to use it in favor of the composite action. The composite action does not support changing runners, which means compilation on non-native platforms has to be done using qemu emulation which can be very slow. The reusable workflow is currently setup to run on amd64 and arm64 runners to avoid emulation. If new platforms are added they will use emulation by default unless the workflow is updated to switch runners based on os and arch inputs. In order for a buildpacks to support multi-arch dependency the respective business logic in the dependency folder of each buildpack must be updated to add dependencies for different os and arch variants, as well as populating the os and arch metadata fields for each individual dependency. I will be updating cpython first and that can be replicated to other repos as needed.

The third commit changes the branch name that is looked for when creating PRs so that it matches the actual branch name where the commits to update buildpack.toml are pushed.

## Use Cases
<!-- An explanation of the use cases your change enables -->
We want multi-arch support for implementation buildpacks so we can eventually ship multi-arch composite buildpacks.

Testing was done with a fork of cpython and go-dist to verify buildpacks with and without compiled dependencies. Links below.

cpython single-arch-verify
https://github.com/jericop/cpython/actions/runs/16981769351
https://github.com/jericop/cpython/pull/9/files#diff-5f54cb49d0e28117084fad482c0daf89502d4ecb329230071fcf78e56dc939b3

cpython multi-arch-verify
https://github.com/jericop/cpython/actions/runs/16982432393
https://github.com/jericop/cpython/pull/10/files#diff-5f54cb49d0e28117084fad482c0daf89502d4ecb329230071fcf78e56dc939b3

go-dist single-arch-verify
https://github.com/jericop/go-dist/actions/runs/16984293635
https://github.com/jericop/go-dist/pull/11


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
