### PR TITLE
fix: replacing skopeo with crane to fetch digest

### DIFF
--- a/implementation/.github/workflows/push-buildpackage.yml
+++ b/implementation/.github/workflows/push-buildpackage.yml
@@ -112,6 +112,7 @@ jobs:
         password: ${{ env.GCR_PASSWORD }}
         registry: ${{ env.GCR_REGISTRY }}
 
+    - uses: buildpacks/github-actions/setup-tools@v5.5.4
     - name: Push to DockerHub
       if: ${{  steps.parse_configs.outputs.push_to_dockerhub == 'true' }}
       id: push
@@ -126,11 +127,14 @@ jobs:
           --buildpack-type ${{ steps.get_buildpack_type.outputs.buildpack_type }} \
           --image-ref "${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}"
 
-        ## Validate that the digest pushed to registry matches with the one mentioned on the readme file
-        pushed_image_index_digest=$(sudo skopeo inspect "docker://${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" | jq -r .Digest)
+        ## Validate that the image index digest pushed to registry matches with the one on the release notes
+        pushed_image_index_digest=$(crane digest "${DOCKERHUB_REGISTRY}/${IMAGE}:${{ steps.event.outputs.tag_full }}" | xargs)
+
+        echo "Index digest from release notes: $(cat ./index-digest.sha256)"
+        echo "Index digest pushed to registry: $pushed_image_index_digest"
 
         if [ "$(cat ./index-digest.sha256)" != "$pushed_image_index_digest" ]; then
-          echo "Image index digest pushed to registry does not match with the one mentioned on the readme file"
+          echo "The image index digest pushed to registry does not match the expected digest from release notes"
           exit 1;
         fi
 


### PR DESCRIPTION
Replaced 'skopeo' with 'crane' for digest inspection.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes the issue with not fetching the index digest for compaing the .sha  https://github.com/paketo-buildpacks/conda-env-update/actions/runs/17445240326/job/49537953476

The fix has been tested here https://github.com/pacostas/conda-env-update/actions/runs/17499919107/job/49710140198

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
