### PR TITLE
Copy linux-amd64 cnb archive to buildpackage.cnb for multi-arch

### DIFF
--- a/language-family/scripts/package.sh
+++ b/language-family/scripts/package.sh
@@ -143,6 +143,11 @@ function buildpackage::create() {
   pack \
     buildpack package "${output}" \
     "${args[@]}"
+
+  if [[ -e "${BUILD_DIR}/buildpackage-linux-amd64.cnb" ]]; then
+    echo "Copying linux-amd64 buildpackage to buildpackage.cnb"
+    cp "${BUILD_DIR}/buildpackage-linux-amd64.cnb" "${BUILD_DIR}/buildpackage.cnb"
+  fi
 }
 
 main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change is needed to allow the release-notes workflows to work for multi-arch buildpacks

## Use Cases
<!-- An explanation of the use cases your change enables -->
Fixes this failure
https://github.com/paketo-buildpacks/python/actions/runs/17674771840/job/50234652780

Tested here
https://github.com/jericop/python/actions/runs/17744944908

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
