### PR TITLE
Switch from array to scalar for image_ref in publish.sh

### DIFF
--- a/implementation/scripts/publish.sh
+++ b/implementation/scripts/publish.sh
@@ -29,7 +29,7 @@ function main {
       ;;
 
     --image-ref | -i)
-      image_ref+=("${2}")
+      image_ref="${2}"
       shift 2
       ;;
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This fixes an issue with the publish script that prevents it from working on mac. The variable should not be an array and this fixes it so it works on mac and linux.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Allow for local testing. Verified the change locally.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
