### PR TITLE
Multi-arch and multi-image support for builders

### DIFF
--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -7,10 +7,94 @@ on:
 
 concurrency: release
 
+env:
+  BUILDERS_FILEPATH: "builders.json"
+
 jobs:
+  preparation:
+    name: Preparation
+    runs-on: ubuntu-24.04
+    outputs:
+      builders: ${{ steps.get-builders.outputs.builders }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Get Builders
+      id: get-builders
+      run: |
+        builders=$(jq -n -c '[]')
+
+        if [ -f ${{ env.BUILDERS_FILEPATH }} ]; then
+          builders=$(jq -c '.builders' ${{ env.BUILDERS_FILEPATH }})
+        else
+          # Strip off the Github org prefix from repo name
+          # paketo-buildpacks/builder-with-some-name --> builder-with-some-name
+          registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///')
+          builders=$(jq -n -c '[
+              {
+                "name": "'"${registry_repo}"'",
+                "path": ".",
+                "container_repository": "'"${registry_repo}"'"
+              }
+            ]')
+        fi
+
+        # Filter only the necessary fields
+        builders=$(echo "$builders" | jq 'map({
+          name,
+          path,
+          container_repository
+        })')
+
+        builders=$(jq -c <<< "$builders")
+        echo "builders=$builders"
+        echo "builders=$builders" >> "$GITHUB_OUTPUT"
+
+  builder_files_changed:
+    name: Builder Files Changed
+    runs-on: ubuntu-24.04
+    needs: preparation
+    outputs:
+      builders_changed: ${{ steps.compare_previous_release.outputs.builders_changed }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # gets full history
+
+    - name: Compare previous releases
+      id: compare_previous_release
+      run: |
+        builders=$(echo '${{ needs.preparation.outputs.builders }}' | jq -c '.[]')
+        for builder in $builders; do
+          builder_path=$(echo "$builder" | jq -r '.path')
+
+          changed=$(git diff --name-only $(git describe --tags --abbrev=0) -- $builder_path/builder.toml)
+          if [ -z "${changed}" ]
+          then
+            # We do not write on the github output because this step runs multiple times
+            # and it might overwrite any true value written by the else statement.
+            echo "No changes for $builder_path/builder.toml"
+          else
+            echo "Changes detected for $builder_path/builder.toml"
+            echo "builders_changed=true" >> $GITHUB_OUTPUT
+          fi
+        done
+
   smoke:
     name: Smoke Test
     runs-on: ubuntu-24.04
+    needs: [preparation, builder_files_changed]
+    if: ${{ needs.builder_files_changed.outputs.builders_changed == 'true' }}
+    strategy:
+      matrix:
+        builders: ${{ fromJSON(needs.preparation.outputs.builders) }}
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     outputs:
       release_notes: ${{ steps.notes.outputs.body }}
     steps:
@@ -34,43 +118,102 @@ jobs:
         pack-version: ${{ steps.pack-version.outputs.version }}
 
     - name: Run Smoke Tests
-      run: ./scripts/smoke.sh --name builder
+      run: |
+        ./scripts/smoke.sh --builder-dir "${{ matrix.builders.path }}"
 
-    - name: Generate Release Notes
+    - name: Generate builder info
       id: notes
       run: |
-        notes="$(pack inspect-builder builder | grep -v 'Inspecting builder' \
+        registry_builder_name=localhost:5000/${{ matrix.builders.name }}
+
+        ./scripts/publish.sh --builder-toml-path "${{ matrix.builders.path }}/builder.toml" \
+          --builder-image-ref "${registry_builder_name}"
+
+        pack inspect-builder $registry_builder_name | grep -v 'Inspecting builder' \
           | grep -v 'REMOTE:' \
           | grep -v 'LOCAL:' \
           | grep -v '\(not present\)' \
-          | grep -v 'Warning' \
-          | sed -e '/./,$!d' \
-          | awk -F, '{printf "%s\\n", $0}')"
-        echo "body=${notes}" >> "$GITHUB_OUTPUT"
+          | grep -v 'Warning' > "${{ matrix.builders.name }}-info.md"
+
+    - name: Upload info for ${{ matrix.builders.name }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: "${{ matrix.builders.name }}-info.md"
+        path: "${{ matrix.builders.name }}-info.md"
 
   release:
     name: Release
     runs-on: ubuntu-24.04
-    needs: smoke
+    needs: [smoke, preparation]
     steps:
     - name: Checkout With History
       uses: actions/checkout@v5
       with:
         fetch-depth: 0  # gets full history
 
-    - name: Compare With Previous Release
-      id: compare_previous_release
+    - name: Download Release Note File(s)
+      uses: actions/download-artifact@v4
+      with:
+        path: info
+        pattern: "*info.md"
+        merge-multiple: true
+
+    - name: Generate Release Notes and Assets
+      id: generate_release_notes_and_assets
       run: |
-        if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder.toml)" ]
-        then
-          echo "builder_changes=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "builder_changes=true" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+        shopt -s inherit_errexit
+
+        builders=$(echo '${{ needs.preparation.outputs.builders }}' | jq -c '.[]')
+        builders_length=$(echo '${{ needs.preparation.outputs.builders }}' | jq 'length')
+
+        release_notes_dir="info"
+
+        # Start with an empty array
+        assets=$(jq -n -c '[]')
+
+        # Generate release assets only if we have more than one builder
+        if [ "$builders_length" -gt 1 ]; then
+          for builder in $builders; do
+            builder_name=$(echo "$builder" | jq -r '.name')
+
+            assets="$(jq -c \
+              --arg release_notes_dir "${release_notes_dir}" \
+              --arg builder_name "${builder_name}" \
+              '. += [
+                {
+                  "path": ($release_notes_dir + "/" + $builder_name + "-" + "info.md"),
+                  "name": ($builder_name + "-" + "info.md"),
+                  "content_type": "text/markdown"
+                }
+              ]' <<<"${assets}")"
+          done
         fi
+
+        echo "assets=${assets}" >> "$GITHUB_OUTPUT"
+
+        # translates 'paketo-buildpacks' to 'paketobuildpacks'
+        DOCKERHUB_ORG="${GITHUB_REPOSITORY_OWNER/-/}"
+
+        release_body=""
+        if [ "$builders_length" -gt 1 ]; then
+          for builder in $builders; do
+            container_repository=$(echo "$builder" | jq -r '.container_repository')
+            release_body+="Builder: \`${DOCKERHUB_ORG}/${container_repository}\`\n"
+          done
+          payload="{\"body\" : \"\n${release_body}\"}"
+        else
+          builder=$(echo "$builders" | head -n 1)
+          release_body="$(cat $release_notes_dir/$(echo "$builder" | jq -r '.name')-info.md \
+          | sed -e '/./,$!d' \
+          | awk -F, '{printf "%s\\n", $0}')"
+          payload="{\"body\" : \"\`\`\`\n${release_body}\n\`\`\`\"}"
+        fi
+
+        echo "release_body=${payload}" >> "$GITHUB_OUTPUT"
 
     - name: Publish Release
       id: publish
-      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
       uses: release-drafter/release-drafter@v6
       with:
         config-name: release-drafter-config.yml
@@ -79,22 +222,38 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
     - name: Update Release Notes
-      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
       run: |
         set -euo pipefail
         shopt -s inherit_errexit
 
-        payload="{\"body\" : \"\`\`\`\n${RELEASE_BODY}\n\`\`\`\"}"
-
+        payload='${{ steps.generate_release_notes_and_assets.outputs.release_body }}'
         curl --fail \
           -X PATCH \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
           -d "${payload}"
+
+        assets='${{ steps.generate_release_notes_and_assets.outputs.assets }}'
+
+        # Update release assets
+        for row in $(echo "${assets}" | jq -c '.[]'); do
+          path=$(echo "$row" | jq -r '.path')
+          name=$(echo "$row" | jq -r '.name')
+          content_type=$(echo "$row" | jq -r '.content_type')
+
+          echo "Uploading asset: ${name} from path: ${path}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Content-Type: ${content_type}" \
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${name}" \
+            --data-binary "@${path}"
+        done
       env:
         RELEASE_ID: ${{ steps.publish.outputs.id }}
-        RELEASE_BODY: ${{ needs.smoke.outputs.release_notes }}
         GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
   failure:

--- a/builder/.github/workflows/push-image.yml
+++ b/builder/.github/workflows/push-image.yml
@@ -5,58 +5,88 @@ on:
     types:
     - published
 
+env:
+  BUILDERS_FILEPATH: "builders.json"
+
 jobs:
-  push:
-    name: Push
+  preparation:
+    name: Preparation
     runs-on: ubuntu-24.04
+    outputs:
+      builders: ${{ steps.get-builders.outputs.builders }}
+      tag: ${{ steps.event.outputs.tag }}
     steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Get Builders
+      id: get-builders
+      run: |
+        builders=$(jq -n -c '[]')
+
+        if [ -f ${{ env.BUILDERS_FILEPATH }} ]; then
+          builders=$(jq -c '.builders' ${{ env.BUILDERS_FILEPATH }})
+        else
+          # Strip off the Github org prefix from repo name
+          # paketo-buildpacks/builder-with-some-name --> builder-with-some-name
+          registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///')
+          builders=$(jq -n -c '[
+              {
+                "name": "'"${registry_repo}"'",
+                "path": ".",
+                "container_repository": "'"${registry_repo}"'"
+              }
+            ]')
+        fi
+
+        # Filter only the necessary fields
+        builders=$(echo "$builders" | jq 'map({
+          name,
+          path,
+          container_repository
+        })')
+
+        builders=$(jq -c <<< "$builders")
+        echo "builders=$builders"
+        echo "builders=$builders" >> "$GITHUB_OUTPUT"
 
     - name: Parse Event
       id: event
       run: |
         echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
 
+  push:
+    name: Push
+    needs: preparation
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        builders: ${{ fromJSON(needs.preparation.outputs.builders) }}
+    steps:
+
     - name: Checkout
       uses: actions/checkout@v5
 
-    - name: Get pack version
-      id: pack-version
-      run: |
-        version=$(jq -r .pack "scripts/.util/tools.json")
-        echo "version=${version#v}" >> "$GITHUB_OUTPUT"
-
-    - name: Install Global Pack
-      uses: buildpacks/github-actions/setup-pack@main
-      with:
-        pack-version: ${{ steps.pack-version.outputs.version }}
-
-    - name: Enable Experimental Pack Features
-      run: |
-        if [ -f "scripts/options.json" ] && jq -e -r .pack_config_enable_experimental "scripts/options.json" > /dev/null; then
-          pack config experimental true
-        fi
-
-    - name: Create Builder Image
-      run: |
-        pack builder create builder --config builder.toml
-
-    - name: Push To Dockerhub
+    - name: Create Builder Image and Push To Dockerhub
       env:
         PAKETO_BUILDPACKS_DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
         PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       run: |
+        # shellcheck source=./scripts/.util/tools.sh
+        source "./scripts/.util/tools.sh"
+
+        util::tools::crane::install --directory "./.bin"
+
         DOCKERHUB_ORG="${GITHUB_REPOSITORY_OWNER/-/}" # translates 'paketo-buildpacks' to 'paketobuildpacks'
-        # Strip off the Github org prefix from repo name
-        # paketo-buildpacks/builder-with-some-name --> builder-with-some-name
-        registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///')
+        container_repository=${{ matrix.builders.container_repository }}
 
         echo "${PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD}" | docker login --username "${PAKETO_BUILDPACKS_DOCKERHUB_USERNAME}" --password-stdin
-        docker tag builder "${DOCKERHUB_ORG}/${registry_repo}:latest"
-        docker tag builder "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}"
 
-        docker push "${DOCKERHUB_ORG}/${registry_repo}:latest"
-        docker push "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}"
+        ./scripts/publish.sh --builder-toml-path "${{ matrix.builders.path }}/builder.toml" \
+          --builder-image-ref "${DOCKERHUB_ORG}/${container_repository}:${{ needs.preparation.outputs.tag }}"
+
+        ./.bin/crane copy "${DOCKERHUB_ORG}/${container_repository}:${{ needs.preparation.outputs.tag }}" "${DOCKERHUB_ORG}/${container_repository}:latest"
 
   failure:
     name: Alert on Failure

--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -7,10 +7,58 @@ on:
 
 concurrency: builder_update
 
+env:
+  BUILDERS_FILEPATH: "builders.json"
+
 jobs:
+  preparation:
+    name: Preparation
+    runs-on: ubuntu-24.04
+    outputs:
+      builders: ${{ steps.get-builders.outputs.builders }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Get Builders
+      id: get-builders
+      run: |
+        builders=$(jq -n -c '[]')
+
+        if [ -f ${{ env.BUILDERS_FILEPATH }} ]; then
+          builders=$(jq -c '.builders' ${{ env.BUILDERS_FILEPATH }})
+        else
+          # Strip off the Github org prefix from repo name
+          # paketo-buildpacks/builder-with-some-name --> builder-with-some-name
+          registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///')
+          builders=$(jq -n -c '[
+              {
+                "name": "'"${registry_repo}"'",
+                "path": ".",
+                "container_repository": "'"${registry_repo}"'"
+              }
+            ]')
+        fi
+
+        # Filter only the necessary fields
+        builders=$(echo "$builders" | jq 'map({
+          name,
+          path,
+          container_repository
+        })')
+
+        builders=$(jq -c <<< "$builders")
+        echo "builders=$builders"
+        echo "builders=$builders" >> "$GITHUB_OUTPUT"
+
   update:
     name: Update builder.toml
     runs-on: ubuntu-24.04
+    needs: preparation
+    strategy:
+      matrix:
+        builders: ${{ fromJSON(needs.preparation.outputs.builders) }}
+
     steps:
     - name: Check out
       uses: actions/checkout@v5
@@ -18,19 +66,20 @@ jobs:
     - name: Checkout branch
       uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
       with:
-        branch: "automation/builder-toml"
+        branch: "automation/${{ matrix.builders.name }}-builder-toml"
 
     - name: Update builder.toml
       uses: paketo-buildpacks/github-config/actions/builder/update@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        filename: "${{ matrix.builders.path }}/builder.toml"
 
     - name: Git commit
       id: commit
       uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
       with:
-        message: "Update builder.toml"
-        pathspec: "builder.toml"
+        message: "Update ${{ matrix.builders.name }} builder.toml"
+        pathspec: "${{ matrix.builders.path }}/builder.toml"
         keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
         key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
@@ -38,15 +87,15 @@ jobs:
       if: ${{ steps.commit.outputs.commit_sha != '' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
       with:
-        branch: "automation/builder-toml"
+        branch: "automation/${{ matrix.builders.name }}-builder-toml"
 
     - name: Open Pull Request
       if: ${{ steps.commit.outputs.commit_sha != '' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/open@main
       with:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-        title: "Updating builder.toml"
-        branch: "automation/builder-toml"
+        title: "Updating ${{ matrix.builders.name }} builder.toml"
+        branch: "automation/${{ matrix.builders.name }}-builder-toml"
 
   failure:
     name: Alert on Failure

--- a/builder/scripts/.syncignore
+++ b/builder/scripts/.syncignore
@@ -1,0 +1,1 @@
+options.json

--- a/builder/scripts/options.json
+++ b/builder/scripts/options.json
@@ -1,0 +1,3 @@
+{
+  "push_builder_to_local_registry": true
+}

--- a/builder/scripts/publish.sh
+++ b/builder/scripts/publish.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly ROOT_DIR="$(cd "${PROGDIR}/.." && pwd)"
+readonly BIN_DIR="${ROOT_DIR}/.bin"
+
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${PROGDIR}/.util/tools.sh"
+
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${PROGDIR}/.util/print.sh"
+
+if [[ $BASH_VERSINFO -lt 4 ]]; then
+  util::print::error "Before running this script please update Bash to v4 or higher (e.g. on OSX: \$ brew install bash)"
+fi
+
+function main() {
+  local token
+  local builder_toml_path=""
+  local builder_image_ref=""
+  token=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
+
+      --builder-toml-path)
+        builder_toml_path=${2}
+        shift 2
+        ;;
+
+      --builder-image-ref)
+        builder_image_ref=${2}
+        shift 2
+        ;;
+
+      --token|-t)
+        token="${2}"
+        shift 2
+        ;;
+
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+
+  if [ -z "$builder_toml_path" ]; then
+    util::print::error "--builder-toml-path is required [Example: ./builders/builder/builder.toml]"
+  fi
+
+  if [ ! -f "$builder_toml_path" ]; then
+    util::print::error "The provided --builder-toml-path does not exist or is not a file: $builder_toml_path"
+  fi
+
+  if [ -z "$builder_image_ref" ]; then
+    util::print::error "--builder-image-ref is required [Example: index.docker.io/username/builder:tag or localhost:5000/builder:tag]"
+  fi
+
+  tools::install "${token}"
+
+  builder::publish "$builder_toml_path" "$builder_image_ref"
+}
+
+function usage() {
+  cat <<-USAGE
+publish.sh [OPTIONS]
+
+  --builder-toml-path PATH          Path to the builder.toml file that defines the builder to be published, e.g. ./builders/builder/builder.toml
+  --builder-image-ref  IMAGE_REF    Full image name of the registry to push the built builder to, e.g. index.docker.io/username/builder:tag or localhost:5000/builder:tag
+  --help, -h                        Show this help message
+USAGE
+}
+
+function tools::install() {
+  local token
+  token="${1}"
+
+  util::tools::pack::install \
+    --directory "${ROOT_DIR}/.bin" \
+    --token "${token}"
+}
+
+function builder::publish() {
+  local builder_toml_path="$1"
+  local builder_image_ref="$2"
+
+  util::print::title "Publishing builder image ${builder_image_ref} using builder config ${builder_toml_path}..."
+  pack builder create "${builder_image_ref}" \
+    --config "${builder_toml_path}" \
+    --publish
+}
+
+
+
+main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Enables builders to support multiple architectures 
* Enables builders to support producing multiple images based on the description of the RFC https://github.com/paketo-buildpacks/rfcs/blob/b550e96431755d7e94b0dcb4ac2d98aa73c90c23/text/0061-core-builder.md
* Alters the output of the release notes to include only the builder names that are published to the registry and adding the  information of the builder as an asset, in case the builder is more than one. Example of a release output: https://github.com/pacostas/builder-jammy-buildpackless-base/releases/tag/v0.1.0 
* It supports backward compatibility, so it will not break any builder workflows

Create release workflow has been tested here https://github.com/pacostas/builder-jammy-buildpackless-base/actions/runs/17878694540 
Push image workflow has been tested here https://github.com/pacostas/builder-jammy-buildpackless-base/actions/runs/17878716651

Push image workflow for backward compatibility has been tested here https://github.com/pacostas/builder-jammy-buildpackless-full/actions/runs/17913086621
Create release workflow for backward compatibility has been tested here https://github.com/pacostas/builder-jammy-buildpackless-full/actions/runs/17913024799

## Use Cases
<!-- An explanation of the use cases your change enables -->
This PR is able to produce multiple images with multiple architectures.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
