### PR TITLE
Create language family buildpackage from release archive

### DIFF
--- a/language-family/scripts/package.sh
+++ b/language-family/scripts/package.sh
@@ -111,6 +111,10 @@ function tools::install() {
   util::tools::pack::install \
     --directory "${BIN_DIR}" \
     --token "${token}"
+
+  util::tools::yj::install \
+    --directory "${BIN_DIR}" \
+    --token "${token}"
 }
 
 function buildpack::archive() {
@@ -131,7 +135,7 @@ function buildpack::release::archive() {
 
   util::print::title "Packaging buildpack into ${BUILD_DIR}/buildpack-release-artifact.tgz..."
 
-  tmp_dir=$(mktemp -d -p $ROOT_DIR)
+  tmp_dir=$(mktemp -d -p $BUILD_DIR)
 
   cat <<'README_EOF' > $tmp_dir/README.md
 # Composite buildpack release artifact
@@ -143,7 +147,7 @@ It contains the following files:
 * `buildpack.toml` - this is needed because it contains the buildpacks and ordering information for the composite buildpack
 * `package.toml` - this is needed because it contains the dependencies (and URIs) that let pack know where to find the buildpacks referenced in `buildpack.toml`.
   * `package.toml` can contain targets (platforms) for multi-arch support
-* `build/buildpack.tgz` - this is needed because it contains the actual buildpack referenced in `package.toml`
+* `build/buildpack.tgz` - this is added because it is referenced in `package.toml` by some buildpacks
 
 ## package locally
 
@@ -173,36 +177,54 @@ README_EOF
   # add the buildpack.toml from the tgz file because it has the version populated
   tar -xzf ${BUILD_DIR}/buildpack.tgz -C $tmp_dir/ buildpack.toml
 
-  tar -cvzf ${BUILD_DIR}/buildpack-release-artifact.tgz -C $tmp_dir $(ls $tmp_dir)
+  tar -czf ${BUILD_DIR}/buildpack-release-artifact.tgz -C $tmp_dir $(ls $tmp_dir)
   rm -rf $tmp_dir
 }
 
 function buildpackage::create() {
-  local output flags
+  local output flags release_archive_path tmp_dir
   output="${1}"
   flags=("${@:2}")
+  release_archive_path="${BUILD_DIR}/buildpack-release-artifact.tgz"
 
   util::print::title "Packaging buildpack..."
 
+  util::print::info "Extracting release archive..."
+  tmp_dir=$(mktemp -d -p $BUILD_DIR)
+  tar -xvf $release_archive_path -C $tmp_dir
+
+  current_dir=$(pwd)
+  cd $tmp_dir
+
   args=(
-      --config "${ROOT_DIR}/package.toml"
+      --config package.toml
       --format file
     )
 
-
   args+=("${flags[@]}")
-
-  pack \
-    buildpack package "${output}" \
-    ${args[@]}
 
   # Use the local architecture to support running locally and in CI, which will be linux/amd64 by default.
   arch=$(util::tools::arch)
+
+  # If package.toml has no targets we must specify one on the command line, otherwise pack will complain.
+  # This is here for backward compatibility but eventually all package.toml files should have targets defined.
+  if cat package.toml | yj -tj | jq -r .targets | grep -q null; then
+    echo "package.toml has no targets so --target linux/${arch} will be passed to pack"
+    args+=("--target linux/${arch}")
+  fi
+
+  set -x
+  pack \
+    buildpack package "${output}" \
+    ${args[@]}
 
   if [[ -e "${BUILD_DIR}/buildpackage-linux-${arch}.cnb" ]]; then
     echo "Copying linux-${arch} buildpackage to buildpackage.cnb"
     cp "${BUILD_DIR}/buildpackage-linux-${arch}.cnb" "${BUILD_DIR}/buildpackage.cnb"
   fi
+
+  cd $current_dir
+  rm -rf $tmp_dir
 }
 
 main "${@:-}"

--- a/language-family/scripts/publish.sh
+++ b/language-family/scripts/publish.sh
@@ -116,6 +116,7 @@ function buildpack::publish() {
 
   util::print::info "Publishing buildpack to ${image_ref}"
 
+  current_dir=$(pwd)
   cd $tmp_dir
 
   # If package.toml has no targets we must specify one on the command line, otherwise pack will complain.
@@ -135,7 +136,7 @@ function buildpack::publish() {
     --publish \
     ${targets}
 
-  cd $ROOT_DIR
+  cd $current_dir
   rm -rf $tmp_dir
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change:
* Updates `language-family/scripts/package.sh` so that the bulidpackage.cnb file is created from the release artifact rather than from the root of the repo.
  * This is what is being done in the workflows that creats and publish new releases and this will make it consistent
  * It will also allow for testing the creation of new releases locally and catch any errors when calling `pack buildpack package`.
* Updates `language-family/scripts/publish.sh`so that it changes back to the original directory rather than ROOT_DIR.

Another benefit to this change is that it means the integration tests will now work on the local architecture being tested. This will allow us to eventually update the integration test workflows to run on multiple runners (arm64 and amd64) so we can verify tests pass on all architectures defined in package.toml `targets`.

This has been tested locally to verify it works as expected. I can push the changes to a fork if needed, but I think local testing is sufficient in this case.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Consistent packaging and release scripts for language family buildpacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
