### PR TITLE
Adding action for syncing test data based on the builders.json file

### DIFF
--- a/builder/.github/workflows/update-test-data.yml
+++ b/builder/.github/workflows/update-test-data.yml
@@ -31,7 +31,7 @@ jobs:
           echo "exists=true" >> $GITHUB_OUTPUT
         fi
 
-    - name: Checkout github-config
+    - name: Checkout paketo-buildpacks samples
       if: ${{ steps.builder_file_exists.outputs.exists == 'true' }}
       uses: actions/checkout@v5
       with:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* adds an action which syncs daily the test data of the smoke tests of buidlers from the paketo-buildpackes/samples based on what is specified on the builders.json file
* Adds as the label on the PR as `semver:patch` for allowing the PR to merge automatically
* In case there is no builders.json or test_data attribute on the builders.json, the workflow will not update anything, therefore is backward compatible with builders who dont have a builders.json file.

This action has been tested:
* here: https://github.com/pacostas/ubuntu-noble-builder/actions/runs/18353727294

Sample PR in case of test data deviates from the samples:
* https://github.com/pacostas/ubuntu-noble-builder/pull/8

Example of builders.json for syncing testdata files
```json
{
  "builders": [
    {
      "name": "ubuntu-noble-builder-buildpackless",
      "path": "./builders/builder-buildpackless",
      "container_repository": "ubuntu-noble-builder-buildpackless",
      "test_runners": ["ubuntu-22.04", "ubuntu-22.04-arm"],
      "test_data": [
        {
          "sample_dir": "procfile/procfile-sample",
          "test_dir": "builders/builder-buildpackless/smoke/testdata/procfile"
        }
      ]
    },
    {
      "name": "ubuntu-noble-builder",
      "path": "./builders/builder",
      "container_repository": "ubuntu-noble-builder",
      "test_runners": ["ubuntu-22.04", "ubuntu-22.04-arm"],
      "test_data": [
        {
          "sample_dir": "java/native-image/spring-boot-native-image-maven",
          "test_dir": "builders/builder/smoke/testdata/spring-boot-native-image-maven"
        },
        {
          "sample_dir": "procfile/procfile-sample",
          "test_dir": "builders/builder/smoke/testdata/procfile"
        }
      ]
    }
  ]
}

```
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
