### PR TITLE
Add syncignore functionality on syncing builders testdata

### DIFF
--- a/builder/.github/workflows/update-test-data.yml
+++ b/builder/.github/workflows/update-test-data.yml
@@ -57,18 +57,32 @@ jobs:
                   exit 1
                 fi
 
+                sample_dir="samples/${sample_dir}/"
+
                 test_dir=$(echo $td | jq -r '.test_dir // empty')
                 if [ -z "$test_dir" ]; then
                   echo "test_dir can not be empty"
                   exit 1
                 fi
+                test_dir="${test_dir}/"
 
                 echo
-                echo "syncing $sample_dir to $test_dir"
+                echo "syncing from ${sample_dir} to ${test_dir}"
                 echo
 
-                args=()
-                args+=("-vr" "--delete" "samples/$sample_dir/" "$test_dir/")
+                args=(
+                  --recursive
+                  "${sample_dir}"
+                  "${test_dir}"
+                  --delete
+                )
+
+                if [[ -f "${test_dir}/.syncignore" ]]; then
+                  args+=(
+                    --exclude=".syncignore"
+                    --exclude-from="${test_dir}/.syncignore"
+                  )
+                fi
 
                 rsync ${args[*]}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds .syncignore functionality on while syncing builders testdata files.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
