### PR TITLE
Add renovate config for buildpacks

### DIFF
--- a/renovate/renovate-buildpack.json
+++ b/renovate/renovate-buildpack.json
@@ -2,19 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>paketo-buildpacks/github-config//renovate/renovate-default"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^buildpack.toml$"
-      ],
-      "matchStrings": [
-        "api = \"(?<currentValue>\\d+?\\.\\d+?)\""
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "buildpacks/spec",
-      "extractVersionTemplate": "^buildpack/v?(?<version>.*)$"
-    }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This serves as a basic configuration for dependency updates via renovate for buildpack repositories. Currently, this replaces dependabot updates only, so every dependency managed by paketo-bot needs some more investigation.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
