### PR TITLE
Remove running linting on main, after PR has been merged

### DIFF
--- a/implementation/.github/workflows/codeql-analysis.yml
+++ b/implementation/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:

--- a/implementation/.github/workflows/lint.yml
+++ b/implementation/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-    - main
   pull_request:
     branches:
     - main

--- a/language-family/.github/workflows/lint.yml
+++ b/language-family/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-    - main
   pull_request:
     branches:
     - main


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The linter actions, run on main branch, after the PR has been merged. This is unecessary

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
