### PR TITLE
Updating builders in one PR

### DIFF
--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -1,4 +1,4 @@
-name: Update builder.toml and Send Pull Request
+name: Update builder.toml files and Send Pull Request
 
 on:
   schedule:
@@ -54,6 +54,8 @@ jobs:
   update:
     name: Update builder.toml
     runs-on: ubuntu-24.04
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
     needs: preparation
     strategy:
       matrix:
@@ -66,7 +68,7 @@ jobs:
     - name: Checkout branch
       uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
       with:
-        branch: "automation/${{ matrix.builders.name }}-builder-toml"
+        branch: "automation/builder-toml-update"
 
     - name: Update builder.toml
       uses: paketo-buildpacks/github-config/actions/builder/update@main
@@ -87,21 +89,29 @@ jobs:
       if: ${{ steps.commit.outputs.commit_sha != '' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
       with:
-        branch: "automation/${{ matrix.builders.name }}-builder-toml"
+        branch: "automation/builder-toml-update"
 
+    - name: Output commit sha
+      run: echo "commit_sha=${{ steps.commit.outputs.commit_sha }}" >> "$GITHUB_OUTPUT"
+
+  open-pull-request:
+    name: Open pull request
+    runs-on: ubuntu-24.04
+    needs: update
+    steps:
     - name: Open Pull Request
-      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      if: ${{ needs.update.outputs.commit_sha != '' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/open@main
       with:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-        title: "Updating ${{ matrix.builders.name }} builder.toml"
-        branch: "automation/${{ matrix.builders.name }}-builder-toml"
+        title: "Updating builder.toml files"
+        branch: "automation/builder-toml-update"
 
   failure:
     name: Alert on Failure
     runs-on: ubuntu-24.04
-    needs: [update]
-    if: ${{ always() && needs.update.result == 'failure' }}
+    needs: [update, open-pull-request]
+    if: ${{ always() && ( needs.update.result == 'failure' || needs.open-pull-request.result == 'failure' ) }}
     steps:
     - name: File Failure Alert Issue
       uses: paketo-buildpacks/github-config/actions/issue/file@main


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR alters the workflow which updates the builders, to instead of opening as many PRs as the builders, it opens one PR  with multiple commints as many as he builders. This is useful because having multiple PRs ends up merging and rebase the rest of the PRs

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
