### PR TITLE
Fix Go mismatch for dependency retrieval

### DIFF
--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          # hashFiles returns empty string if file does not exist
+          go-version-file: ${{ hashFiles('dependency/retrieval/go.mod') != '' && 'dependency/retrieval/go.mod' || 'go.mod' }}
 
       - name: Run Retrieve
         id: retrieve


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
If the `dependency/retrieval/go.mod` specifies a later version of Go to the buildpack, it causes an error during dependency update.

This updates the workflow so that the retrieval `go.mod` will be used if present.

Example: https://github.com/paketo-buildpacks/icu/actions/runs/19390830547/job/55484040267

```
## /go.mod
module github.com/paketo-buildpacks/icu

go 1.24.7

## /dependency/retrieval/go.mod
module github.com/paketo-buildpacks/icu/dependency/retrieval

go 1.24.10
```

Error from workflow shows:
```
go: go.mod requires go >= 1.24.10 (running go 1.24.7; GOTOOLCHAIN=local)
make: *** [Makefile:4: retrieve] Error 1
Error: Process completed with exit code 2.
```

Fixes paketo-buildpacks/icu#369

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
