### PR TITLE
Add builder-jammy-base to the repositories list

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -9,5 +9,6 @@ module.exports = {
         "paketo-buildpacks/github-config",
         "paketo-buildpacks/libnodejs",
         "paketo-buildpacks/cpython",
+        "paketo-buildpacks/builder-jammy-base",
     ],
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
As advised in the README.md file, I'm adding the `builder-jammy-base` repository to .github/renovate-config.js to enable Renovate for the target repository.

## Use Cases
Adding Renovate to the `builder-jammy-base` repository will help automatically update minor Go versions, moving away from the vulnerable `1.24.6` (currently in use). See https://github.com/paketo-buildpacks/builder-jammy-base/issues/753

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
