### PR TITLE
Add YJ install function back to language family config

### DIFF
--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -175,6 +175,60 @@ function util::tools::pack::install() {
   fi
 }
 
+function util::tools::yj::install() {
+  local dir token
+  token=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --directory)
+        dir="${2}"
+        shift 2
+        ;;
+
+      --token)
+        token="${2}"
+        shift 2
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  mkdir -p "${dir}"
+  util::tools::path::export "${dir}"
+
+  if [[ ! -f "${dir}/yj" ]]; then
+    local version curl_args os arch
+
+    version="$(jq -r .yj "$(dirname "${BASH_SOURCE[0]}")/tools.json")"
+
+    curl_args=(
+      "--fail"
+      "--silent"
+      "--location"
+      "--output" "${dir}/yj"
+    )
+
+    if [[ "${token}" != "" ]]; then
+      curl_args+=("--header" "Authorization: Token ${token}")
+    fi
+
+    util::print::title "Installing yj ${version}"
+
+    os=$(util::tools::os macos)
+    arch=$(util::tools::arch)
+
+    curl "https://github.com/sclevine/yj/releases/download/${version}/yj-${os}-${arch}" \
+      "${curl_args[@]}"
+
+    chmod +x "${dir}/yj"
+  else
+    util::print::info "Using yj $("${dir}"/yj -v)"
+  fi
+}
+
 function util::tools::packager::install () {
     local dir
     while [[ "${#}" != 0 ]]; do


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Add back the `util::tools::yj::install` function which was inadvertently removed in #1234.

This is required for language-family repos and otherwise causes:

```
Run Buildpack Runtime Integration Tests
Using index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base as builder...
=== RUN   TestIntegration
    init_test.go:21: 
        
        Preparing repo...
        Using jam 2.15.1
        Using pack 0.39.0+git-a8010d1.build-6685
        ../scripts/package.sh: line 116: util::tools::yj::install: command not found
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
