### PR TITLE
Revert changes to lifecycle image prefetch

### DIFF
--- a/implementation/scripts/integration.sh
+++ b/implementation/scripts/integration.sh
@@ -135,15 +135,10 @@ function builder_images::pull() {
       | jq -r '.remote_info.run_images[0].name'
   )"
 
-  os=$(util::tools::os)
-  arch=$(util::tools::arch --format-amd64-x86-64)
-
-  lifecycle_version="$(
+  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
     pack inspect-builder "${builder}" --output json \
       | jq -r '.remote_info.lifecycle.version'
   )"
-
-  lifecycle_image="index.docker.io/buildpacksio/lifecycle:${lifecycle_version}-${os}-${arch}"
 
   util::print::title "Pulling run image..."
   docker pull "${run_image}"

--- a/language-family/scripts/integration.sh
+++ b/language-family/scripts/integration.sh
@@ -135,15 +135,10 @@ function builder_images::pull() {
       | jq -r '.remote_info.run_images[0].name'
   )"
 
-  os=$(util::tools::os)
-  arch=$(util::tools::arch --format-amd64-x86-64)
-
-  lifecycle_version="$(
+  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
     pack inspect-builder "${builder}" --output json \
       | jq -r '.remote_info.lifecycle.version'
   )"
-
-  lifecycle_image="index.docker.io/buildpacksio/lifecycle:${lifecycle_version}-${os}-${arch}"
 
   util::print::title "Pulling run image..."
   docker pull "${run_image}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Reverts the changes to how integration tests pre-fetch the lifecycle image.

Original PR: https://github.com/paketo-buildpacks/github-config/pull/1234
Upstream PR: https://github.com/buildpacks/pack/pull/2498

PR used to test the changes: https://github.com/paketo-buildpacks/dotnet-core/pull/1426

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
