### PR TITLE
Revert "Dependabot: exclude problematic dependencies from group PRs"

### DIFF
--- a/implementation/.github/dependabot.yml
+++ b/implementation/.github/dependabot.yml
@@ -16,8 +16,3 @@ updates:
       update-types:
       - "minor"
       - "patch"
-      exclude-patterns:
-      - "github.com/anchore/stereoscope"
-      - "github.com/testcontainers/testcontainers-go"
-      - "github.com/docker/docker"
-      - "github.com/containerd/containerd"

--- a/language-family/.github/dependabot.yml
+++ b/language-family/.github/dependabot.yml
@@ -16,8 +16,3 @@ updates:
       update-types:
       - "minor"
       - "patch"
-      exclude-patterns:
-      - "github.com/anchore/stereoscope"
-      - "github.com/testcontainers/testcontainers-go"
-      - "github.com/docker/docker"
-      - "github.com/containerd/containerd"


### PR DESCRIPTION
Reverts paketo-buildpacks/github-config#917

The dependencies are not problematic anymore. It is good to revert this PR, as it will reduce the number of PRs from dependabot on each buildpacks