### PR TITLE
Properly fetching if a PR already exists for a specific branch

### DIFF
--- a/actions/pull-request/open/entrypoint
+++ b/actions/pull-request/open/entrypoint
@@ -50,9 +50,7 @@ function main() {
 
   echo "${token}" | gh auth login --with-token
 
-  count="$(gh pr list --repo "${GITHUB_REPOSITORY}" \
-    | awk -v branch="${branch}" '{ if ($(NF-1) == branch) { print }}' \
-    | wc -l)"
+  count="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${branch}" | wc -l)"
 
   if [[ "${count}" != "0" ]]; then
     echo "PR already exists, updated with new commit."


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The github-action which is responsible for opening a PR `paketo-buildpacks/github-config/actions/pull-request/open`, fails to properly check if a PR already exists for this branch, therefore, it fails to open a PR in case the PR already exists.
This PR fixes this issue, by updating the command which fetches the PRs that are open on the repository.

This PR has been tested.

It also fixes: https://github.com/paketo-buildpacks/github-config/issues/1216

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
