### PR TITLE
fix: harmonize all tools helper scripts for macOS

### DIFF
--- a/implementation/scripts/.util/tools.sh
+++ b/implementation/scripts/.util/tools.sh
@@ -158,7 +158,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
 
-    os=$(util::tools::os)
+    os=$(util::tools::os macos)
     arch=$(util::tools::arch --blank-amd64)
 
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}${arch:+-$arch}.tgz" \

--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -158,7 +158,7 @@ function util::tools::pack::install() {
 
     util::print::title "Installing pack ${version}"
 
-    os=$(util::tools::os)
+    os=$(util::tools::os macos)
     arch=$(util::tools::arch --blank-amd64)
 
     curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}${arch:+-$arch}.tgz" \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Harmonize the tools helper scripts so that pack installation works in all cases.

Currently, running integration tests does not work on macOS as pack fails to download.

The builder and stack tools helper scripts already had the fix to install pack on macOS.

This patch harmonizes that.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Run integration tests on macOS while developing buildpacks

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
