### PR TITLE
Downgrade upload artifact to v6 from v7

### DIFF
--- a/builder/.github/workflows/create-release.yml
+++ b/builder/.github/workflows/create-release.yml
@@ -197,7 +197,7 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download Release Note File(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: info
         pattern: "*info.md"

--- a/implementation/.github/workflows/update-dependencies-from-metadata.yml
+++ b/implementation/.github/workflows/update-dependencies-from-metadata.yml
@@ -195,7 +195,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download artifact files
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           name: "${{ needs.retrieve.outputs.id }}-${{ matrix.includes.version }}-${{ matrix.includes.os != '' && matrix.includes.os || 'linux' }}-${{ matrix.includes.arch != '' && matrix.includes.arch || 'amd64' }}-${{ matrix.includes.target }}"
 
@@ -229,7 +229,7 @@ jobs:
         run: echo "checksum=$(cat ${{ steps.get-file-names.outputs.checksum-file }})" >> "$GITHUB_OUTPUT"
 
       - name: Download metadata.json
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           name: metadata.json
 
@@ -299,7 +299,7 @@ jobs:
 
       # Metadata file for the non-compiled dependencies, if there are any
       - name: Download metadata.json file
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           path: "${{ steps.make-outputdir.outputs.outputdir }}/metadata-files"
           pattern: "from-source-metadata.json"
@@ -309,7 +309,7 @@ jobs:
       # Download each metadata file, and combine them into one
       - name: Download individual metadata-file.json file(s)
         if: ${{ needs.update-metadata.result == 'success' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           path: "${{ steps.make-outputdir.outputs.outputdir }}/metadata-files"
           pattern: "*metadata-file.json"

--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -665,7 +665,7 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download Current Receipt(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         pattern: current-*-receipt-${{ matrix.stacks.name }}
         path: receipt-files
@@ -832,7 +832,7 @@ jobs:
 
     - name: Download USN File(s)
       if: ${{ needs.preparation.outputs.polling_type == 'usn' }}
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: "patched-usns"
         pattern: ${{ matrix.arch.name }}-*${{ env.PATCHED_USNS_FILENAME }}
@@ -933,7 +933,7 @@ jobs:
       packages_changed: ${{ steps.compare.outputs.packages_changed }}
     steps:
     - name: Download diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         name: diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
 
@@ -983,12 +983,12 @@ jobs:
         go-version-file: go.mod
 
     - name: Download Build Image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         pattern: current-build-image-*
 
     - name: Download Run Image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         pattern: current-run-image-*
 
@@ -1031,13 +1031,13 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download current build image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: image-files
         pattern: current-build-image-*
 
     - name: Download current run image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: image-files
         pattern: current-run-image-*
@@ -1046,14 +1046,14 @@ jobs:
       run: ls image-files
 
     - name: Download Build Receipt(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: receipt-files
         pattern: current-build-receipt-*
         merge-multiple: true
 
     - name: Download Run Receipt(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: receipt-files
         pattern: current-run-receipt-*
@@ -1063,7 +1063,7 @@ jobs:
       run: ls receipt-files
 
     - name: Download Release Note File(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: release-notes
         pattern: "*release-notes.md"
@@ -1074,7 +1074,7 @@ jobs:
 
     - name: Download hash code Files
       if: ${{ needs.preparation.outputs.polling_type == 'hash' }}
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: hash-code-files
         pattern: hash-code-*
@@ -1086,7 +1086,7 @@ jobs:
 
     - name: Download USN Files
       if: ${{ needs.preparation.outputs.polling_type == 'usn' }}
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         path: usn-files
         pattern: "*${{ env.PATCHED_USNS_FILENAME }}"

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -97,12 +97,12 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Download Build Image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         pattern: current-build-image-*
 
     - name: Download Run Image(s)
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v6
       with:
         pattern: current-run-image-*
 


### PR DESCRIPTION
Upload and download artifact actions, have to be on the same version in order to cooperate. There is no upload version v7, so we have to downgrade the download one to v6.

Reverts paketo-buildpacks/github-config#1244