### PR TITLE
downgrading upload and download artifact to version 4

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -389,7 +389,7 @@ jobs:
         usns_output_path: "./${{ matrix.arch.name }}-${{ matrix.stacks.name }}-${{ env.PATCHED_USNS_FILENAME }}"
 
     - name: Upload USNs file
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: "${{ matrix.arch.name }}-${{ matrix.stacks.name }}-${{ env.PATCHED_USNS_FILENAME }}"
         path: "${{ matrix.arch.name }}-${{ matrix.stacks.name }}-${{ env.PATCHED_USNS_FILENAME }}"
@@ -483,7 +483,7 @@ jobs:
         fi
 
     - name: Upload run image hash code
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: hash-code-current-run-image-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
         path: hash-code-current-run-image-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
@@ -491,7 +491,7 @@ jobs:
 
     - name: Upload build image hash code
       if: ${{ matrix.stacks.create_build_image == true }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: hash-code-current-build-image-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
         path: hash-code-current-build-image-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
@@ -615,7 +615,7 @@ jobs:
                             --run-receipt current-run-receipt-${{ matrix.stacks.name }}
 
     - name: Upload run image
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-run-image-${{ matrix.stacks.name }}
         path: "${{ matrix.stacks.output_dir }}/run.oci"
@@ -623,7 +623,7 @@ jobs:
 
     - name: Upload build image
       if: ${{ matrix.stacks.create_build_image == true }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-build-image-${{ matrix.stacks.name }}
         path: "${{ matrix.stacks.output_dir }}/build.oci"
@@ -631,14 +631,14 @@ jobs:
 
     - name: Upload Build receipt
       if: ${{ matrix.stacks.create_build_image == true }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-build-receipt-${{ matrix.stacks.name }}
         path: "*current-build-receipt-${{ matrix.stacks.name }}"
         if-no-files-found: error
 
     - name: Upload Run receipt
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-run-receipt-${{ matrix.stacks.name }}
         path: "*current-run-receipt-${{ matrix.stacks.name }}"
@@ -670,7 +670,7 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download Current Receipt(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         pattern: current-*-receipt-${{ matrix.stacks.name }}
         path: receipt-files
@@ -829,7 +829,7 @@ jobs:
         cp "${{ github.workspace }}/${{ env.RUN_DIFF_REMOVED_FILENAME }}" "$diffs_dir/run_removed_with_force"
 
     - name: Upload diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
         path: diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
@@ -837,7 +837,7 @@ jobs:
 
     - name: Download USN File(s)
       if: ${{ needs.preparation.outputs.polling_type == 'usn' }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: "patched-usns"
         pattern: ${{ matrix.arch.name }}-*${{ env.PATCHED_USNS_FILENAME }}
@@ -919,7 +919,7 @@ jobs:
         release_body_file: "${{ matrix.arch.name }}-${{ matrix.stacks.name }}-release-notes.md"
 
     - name: Upload ${{ matrix.arch.name }} release notes file for stack ${{ matrix.stacks.name }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: "${{ matrix.arch.name }}-${{ matrix.stacks.name }}-release-notes.md"
         path: "${{ matrix.arch.name }}-${{ matrix.stacks.name }}-release-notes.md"
@@ -938,7 +938,7 @@ jobs:
       packages_changed: ${{ steps.compare.outputs.packages_changed }}
     steps:
     - name: Download diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         name: diff-${{ matrix.arch.name }}-${{ matrix.stacks.name }}
 
@@ -988,12 +988,12 @@ jobs:
         go-version-file: go.mod
 
     - name: Download Build Image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         pattern: current-build-image-*
 
     - name: Download Run Image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         pattern: current-run-image-*
 
@@ -1036,13 +1036,13 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download current build image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: image-files
         pattern: current-build-image-*
 
     - name: Download current run image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: image-files
         pattern: current-run-image-*
@@ -1051,14 +1051,14 @@ jobs:
       run: ls image-files
 
     - name: Download Build Receipt(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: receipt-files
         pattern: current-build-receipt-*
         merge-multiple: true
 
     - name: Download Run Receipt(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: receipt-files
         pattern: current-run-receipt-*
@@ -1068,7 +1068,7 @@ jobs:
       run: ls receipt-files
 
     - name: Download Release Note File(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: release-notes
         pattern: "*release-notes.md"
@@ -1079,7 +1079,7 @@ jobs:
 
     - name: Download hash code Files
       if: ${{ needs.preparation.outputs.polling_type == 'hash' }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: hash-code-files
         pattern: hash-code-*
@@ -1091,7 +1091,7 @@ jobs:
 
     - name: Download USN Files
       if: ${{ needs.preparation.outputs.polling_type == 'usn' }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         path: usn-files
         pattern: "*${{ env.PATCHED_USNS_FILENAME }}"

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -69,7 +69,7 @@ jobs:
                           --build-dir ${{ matrix.stacks.output_dir }}
 
     - name: Upload run image
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-run-image-${{ matrix.stacks.name }}
         path: "${{ matrix.stacks.output_dir }}/run.oci"
@@ -77,7 +77,7 @@ jobs:
 
     - name: Upload build image
       if: ${{ matrix.stacks.create_build_image == true }}
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: current-build-image-${{ matrix.stacks.name }}
         path: "${{ matrix.stacks.output_dir }}/build.oci"
@@ -97,12 +97,12 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Download Build Image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         pattern: current-build-image-*
 
     - name: Download Run Image(s)
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v4
       with:
         pattern: current-run-image-*
 
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: event-payload
         path: ${{ github.event_path }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR is only for the stacks/ base images.
The latest version for upload and download github actions, do not run as expected. Until there is a proper patch, is better to stay on a version that works for the stacks/base images

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
