### PR TITLE
Pinning builder lifecycle to 0.21.1

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -57,5 +57,8 @@ runs:
       #!/usr/bin/env bash
       set -euo pipefail
       shopt -s inherit_errexit
+      builder_file="${PWD}/${{ inputs.filename }}"
       jam update-builder \
-        --builder-file "${PWD}/${{ inputs.filename }}"
+        --builder-file "$builder_file"
+      # Pin lifecycle version to 0.21.1
+      sed -i '/^\[lifecycle\]/,/^\[/ { s/version = "[^"]*"/version = "0.21.1"/ }' "$builder_file"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR pins lifecycle version of the builders to 0.21.1 to avoid upgrade, until the issue has been resolve. That way we do not block buildpack updates.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
