### PR TITLE
fix: make yj installable on macOS

### DIFF
--- a/language-family/scripts/.util/tools.sh
+++ b/language-family/scripts/.util/tools.sh
@@ -217,7 +217,7 @@ function util::tools::yj::install() {
 
     util::print::title "Installing yj ${version}"
 
-    os=$(util::tools::os)
+    os=$(util::tools::os, macos)
     arch=$(util::tools::arch)
 
     curl "https://github.com/sclevine/yj/releases/download/${version}/yj-${os}-${arch}" \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When install yj, use the same os logic as for pack to get the proper release from GitHub.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Development done on macOS

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
