### PR TITLE
[implementation][scripts] Add config::build function to copy php-dist…

### DIFF
--- a/implementation/scripts/build.sh
+++ b/implementation/scripts/build.sh
@@ -44,6 +44,7 @@ function main() {
 
   run::build
   cmd::build
+  config::build
 
   ## For backwards compatibility with amd64 workflows
   if [[ ${#targets[@]} -eq 1 && "${targets[0]}" == "linux/amd64" ]]; then
@@ -130,6 +131,22 @@ function cmd::build() {
           printf "%s" "Skipping ${name}... "
         fi
       done
+    done
+  fi
+}
+
+function config::build() {
+  if [[ -d "${BUILDPACKDIR}/config" ]]; then
+    for target in "${targets[@]}"; do
+      platform=$(echo "${target}" | cut -d '/' -f1)
+      arch=$(echo "${target}" | cut -d'/' -f2)
+
+      util::print::title "Placing config files... for platform: ${platform} and arch: ${arch}"
+
+      mkdir -p "${BUILDPACKDIR}/${platform}/${arch}/config"
+      cp -r "${BUILDPACKDIR}"/config/* "${BUILDPACKDIR}/${platform}/${arch}/config/" 2>/dev/null || true
+
+      echo "Success!"
     done
   fi
 }


### PR DESCRIPTION
… config

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This adds a config::build function to ensure the config needed for php-dist is present under the path /os/arch/config/XY as the build otherwise fails as can be seen in this test run: https://github.com/paketo-buildpacks/php-dist/actions/runs/22901160138/job/66447799817?pr=1025

Adding the function fixes that issue as you can in this run: https://github.com/paketo-buildpacks/php-dist/actions/runs/22906721803/job/66467450176?pr=1026

The noble tests is what I am actually trying to fix in my PR in php-dist, but that does not have anything to do with the build.sh 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
