### PR TITLE
Skip opening a PR if there are no builder updates

### DIFF
--- a/actions/builder/update/action.yml
+++ b/actions/builder/update/action.yml
@@ -11,51 +11,18 @@ inputs:
     description: 'Name of the builder.toml file to update'
     required: false
     default: 'builder.toml'
+  jam_version:
+    description: 'Jam version to install (e.g. 2.8.0). Use latest or omit to resolve from the GitHub API.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
   steps:
-
-  - name: Choose Jam Version
-    id: version
-    shell: bash
-    run: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-      shopt -s inherit_errexit
-      version="$(
-        curl "https://api.github.com/repos/paketo-buildpacks/jam/releases/latest" \
-          --fail-with-body \
-          --show-error \
-          --header "Authorization: token ${{ inputs.token }}" \
-          --location \
-          --silent \
-        | jq -r -S .tag_name
-      )"
-      echo "version=${version#v}" >> "$GITHUB_OUTPUT"
-
-  - name: Install Jam
-    shell: bash
-    run: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-      shopt -s inherit_errexit
-      mkdir -p "${HOME}"/bin
-      echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
-      mkdir -p "${HOME}/bin"
-      curl "https://github.com/paketo-buildpacks/jam/releases/download/v${{ steps.version.outputs.version }}/jam-linux" \
-        --fail-with-body \
-        --show-error \
-        --silent \
-        --location \
-        --output "${HOME}/bin/jam"
-      chmod +x "${HOME}/bin/jam"
-
-  - name: Update Builder
-    shell: bash
-    run: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-      shopt -s inherit_errexit
-      jam update-builder \
-        --builder-file "${PWD}/${{ inputs.filename }}"
+    - name: Update Builder
+      shell: bash
+      run: |
+        bash "${{ github.action_path }}/entrypoint" \
+          --token "${{ inputs.token }}" \
+          --filename "${{ inputs.filename }}" \
+          --jam-version "${{ inputs.jam_version }}"

--- a/actions/builder/update/entrypoint
+++ b/actions/builder/update/entrypoint
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s inherit_errexit
+
+function usage() {
+  cat <<'EOF'
+Install paketo jam (linux amd64) and run update-builder.
+
+Usage:
+  entrypoint [options]
+
+Options:
+  --token TOKEN       Optional GitHub token.
+  --filename PATH     builder.toml path relative to the working directory (default: builder.toml).
+  --jam-version VER   Jam version without leading v, or "latest", or omit to resolve latest from the API.
+  -h, --help          Show this help and exit.
+EOF
+}
+
+function main() {
+  local token filename jam_version curl_args
+  token=""
+  filename="builder.toml"
+  jam_version=""
+  while [ "${#}" != 0 ]; do
+    case "${1}" in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+
+      --token)
+        token="${2}"
+        shift 2
+        ;;
+
+      --filename)
+        filename="${2}"
+        shift 2
+        ;;
+
+      --jam-version)
+        jam_version="${2}"
+        shift 2
+        ;;
+
+      "")
+        shift
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\"" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  curl_args=(
+    "--fail-with-body"
+    "--show-error"
+    "--location"
+    "--silent"
+  )
+
+  if [[ "${token}" != "" ]]; then
+    curl_args+=("--header" "Authorization: Token ${token}")
+  fi
+
+  if [[ -z "${jam_version}" || "${jam_version}" == "latest" ]]; then
+    jam_version="$(
+      curl "${curl_args[@]}" \
+        "https://api.github.com/repos/paketo-buildpacks/jam/releases/latest" \
+      | jq -r -S .tag_name
+    )"
+  fi
+
+  jam_version="${jam_version#v}"
+
+  mkdir -p "${HOME}/bin"
+
+  curl "${curl_args[@]}" \
+    "https://github.com/paketo-buildpacks/jam/releases/download/v${jam_version}/jam-linux" \
+    --output "${HOME}/bin/jam"
+
+  echo "curl ${curl_args[@]} https://github.com/paketo-buildpacks/jam/releases/download/v${jam_version}/jam-linux --output ${HOME}/bin/jam"
+
+  chmod +x "${HOME}/bin/jam"
+
+  "${HOME}/bin/jam" update-builder \
+    --builder-file "${PWD}/${filename}"
+}
+
+main "${@:-}"

--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -124,7 +124,20 @@ jobs:
       with:
         branch: "automation/builder-toml-update"
 
+    - name: Check if branch has commits
+      id: check-if-commits
+      run: |
+       # get the number of commits in the branch
+       commits=$(git rev-list --count automation/builder-toml-update)
+       if [ "$commits" -eq 0 ]; then
+         echo "No commits in branch automation/builder-toml-update"
+         echo "commits=0" >> "$GITHUB_OUTPUT"
+       else
+         echo "commits=$commits" >> "$GITHUB_OUTPUT"
+       fi
+
     - name: Open Pull Request
+      if: ${{ steps.check-if-commits.outputs.commits == '0' }}
       uses: paketo-buildpacks/github-config/actions/pull-request/open@main
       with:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* skips calling the open PR step, if there are no commits on the branch
* Refactors the update builder action, in order to accept jam version. This will be helfpull in order to specify the jam version and not always using the latest one, making the workflows more stable on updates

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
