### PR TITLE
Properly counting commits from main

### DIFF
--- a/builder/.github/workflows/update-builder-toml.yml
+++ b/builder/.github/workflows/update-builder-toml.yml
@@ -126,8 +126,8 @@ jobs:
     - name: Check if branch has commits
       id: check-if-commits
       run: |
-       # get the number of commits in the branch
-       commits=$(git rev-list --count automation/builder-toml-update)
+       # get the number of commits since it branched off from main
+       commits=$(git rev-list --count main..automation/builder-toml-update)
        if [ "$commits" -eq 0 ]; then
          echo "No commits in branch automation/builder-toml-update"
          echo "commits=0" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
A tiny patch for a bug on the builders update toml workflow, as it tries to open a PR all the time due to wrong calculation of new commits.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
