### PR TITLE
feat: add s390x and ppc64le support

### DIFF
--- a/stack/scripts/.util/tools.sh
+++ b/stack/scripts/.util/tools.sh
@@ -38,6 +38,14 @@ function util::tools::arch() {
       fi
       ;;
 
+    s390x)
+      echo "s390x"
+      ;;
+
+    ppc64le)
+      echo "ppc64le"
+      ;;
+
     *)
       util::print::error "Unknown Architecture \"$(uname -m)\""
       exit 1


### PR DESCRIPTION
## Summary
Updates the `util::tools::arch` bash function in `stack/scripts/.util/tools.sh` to correctly identify the `s390x` and `ppc64le` architectures. This prevents the utility scripts from failing with an "Unknown Architecture" error when executed on these hardware platforms.
related : https://github.com/paketo-buildpacks/jammy-tiny-stack/pull/257

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
