### PR TITLE
Adding no stack id implementation

### DIFF
--- a/stack/.github/workflows/create-release.yml
+++ b/stack/.github/workflows/create-release.yml
@@ -110,7 +110,8 @@ jobs:
               is_new,
               stack_type,
               pattern_image_registry_name,
-              pattern_assets_prefix
+              pattern_assets_prefix,
+              no_stack_id
             })')
 
           stacks=$(jq -c <<< "$stacks" )
@@ -637,8 +638,17 @@ jobs:
     - name: Create stack ${{ matrix.stacks.name }}
       id: create-stack
       run: |
-        scripts/create.sh --stack-dir ${{ matrix.stacks.config_dir }} \
-                          --build-dir ${{ matrix.stacks.output_dir }}
+
+        args=(
+            --stack-dir ${{ matrix.stacks.config_dir }}
+            --build-dir ${{ matrix.stacks.output_dir }}
+          )
+
+        if [[ "${{ matrix.stacks.no_stack_id }}" == "true" ]]; then
+          args+=("--no-stack-id")
+        fi
+
+        scripts/create.sh "${args[@]}"
 
     - name: Generate Package Receipts
       id: receipts

--- a/stack/.github/workflows/test-pull-request.yml
+++ b/stack/.github/workflows/test-pull-request.yml
@@ -41,7 +41,8 @@ jobs:
               name,
               config_dir,
               output_dir,
-              create_build_image})')
+              create_build_image,
+              no_stack_id})')
 
           stacks=$(jq -c <<< "$stacks" )
           echo "stacks=$stacks"
@@ -65,8 +66,17 @@ jobs:
     - name: Create stack ${{ matrix.stacks.name }}
       id: create-stack
       run: |
-        scripts/create.sh --stack-dir ${{ matrix.stacks.config_dir }} \
-                          --build-dir ${{ matrix.stacks.output_dir }}
+        args=(
+            --stack-dir ${{ matrix.stacks.config_dir }}
+            --build-dir ${{ matrix.stacks.output_dir }}
+          )
+
+        if [[ "${{ matrix.stacks.no_stack_id }}" == "true" ]]; then
+          args+=("--no-stack-id")
+        fi
+
+        scripts/create.sh "${args[@]}"
+
 
     - name: Upload run image
       uses: actions/upload-artifact@v4

--- a/stack/scripts/create.sh
+++ b/stack/scripts/create.sh
@@ -23,6 +23,7 @@ function main() {
   local stack_dir_name build_dir_name
   stack_dir_name=""
   build_dir_name=""
+  no_stack_id="false"
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
@@ -50,6 +51,11 @@ function main() {
       --build-dir)
         build_dir_name="${2}"
         shift 2
+        ;;
+
+      --no-stack-id)
+        no_stack_id="true"
+        shift 1
         ;;
 
       "")
@@ -126,6 +132,10 @@ function stack::create() {
       --build-output "${build_dirpath}/build.oci"
       --run-output "${build_dirpath}/run.oci"
     )
+
+  if [[ "${no_stack_id}" == "true" ]]; then
+    args+=("--no-stack-id")
+  fi
 
   args+=("${flags[@]}")
 

--- a/stack/scripts/test.sh
+++ b/stack/scripts/test.sh
@@ -118,9 +118,11 @@ function main() {
     while read -r image; do
       config_dir=$(echo "${image}" | jq -r '.config_dir')
       output_dir=$(echo "${image}" | jq -r '.output_dir')
+      no_stack_id=$(echo "${image}" | jq -r '.no_stack_id // false')
       "${ROOT_DIR}/scripts/create.sh" \
         --stack-dir "${config_dir}" \
-        --build-dir "${output_dir}"
+        --build-dir "${output_dir}" \
+        --no-stack-id "${no_stack_id}"
     done <<<"$STACK_IMAGES"
   else
     util::print::title "Stack builds already exist..."


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds support for generating base images without stack id. This is useful for transiationing from stacks to base images. The implementation is already in use on the ubuntu-noble-baase-imasges repo and is also backward compatible so it will not break any of the existing workflows of the current stacks/base images

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
